### PR TITLE
Improve Hibernate queries

### DIFF
--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Alert.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Alert.java
@@ -27,7 +27,7 @@ public class Alert {
 
     // The disease.
     @ManyToOne
-    @JoinColumn(name = "feed_id")
+    @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
 
     // The title of the alert.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Country.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Country.java
@@ -24,7 +24,7 @@ public class Country {
     private Integer gaulCode;
 
     // The country's name.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     public Country() {

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseGroup.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseGroup.java
@@ -33,11 +33,11 @@ public class DiseaseGroup {
     private DiseaseGroup parentGroup;
 
     // The disease group name.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     // The disease group type.
-    @Column(name = "group_type")
+    @Column(name = "group_type", nullable = false)
     @Enumerated(EnumType.STRING)
     private DiseaseGroupType groupType;
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseOccurrence.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseOccurrence.java
@@ -23,8 +23,12 @@ import javax.persistence.Table;
         ),
         @NamedQuery(
                 name = "getDiseaseOccurrencesYetToBeReviewed",
-                query = "from DiseaseOccurrence where diseaseGroup.id=:diseaseGroupId" +
-                        " and id not in (select diseaseOccurrence.id from DiseaseOccurrenceReview where" +
+                query = "from DiseaseOccurrence as d" +
+                        " inner join fetch d.location" +
+                        " inner join fetch d.alert" +
+                        " inner join fetch d.alert.feed" +
+                        " where d.diseaseGroup.id=:diseaseGroupId" +
+                        " and d.id not in (select diseaseOccurrence.id from DiseaseOccurrenceReview where" +
                         " expert.id=:expertId)"
         )
 })
@@ -39,19 +43,20 @@ public class DiseaseOccurrence {
     // The disease group that occurred.
     @ManyToOne
     @Cascade(CascadeType.SAVE_UPDATE)
-    @JoinColumn(name = "disease_group_id")
+    @JoinColumn(name = "disease_group_id", nullable = false)
+    @Fetch(FetchMode.JOIN)
     private DiseaseGroup diseaseGroup;
 
     // The location of this occurrence.
     @ManyToOne
     @Cascade(CascadeType.SAVE_UPDATE)
-    @JoinColumn(name = "location_id")
+    @JoinColumn(name = "location_id", nullable = false)
     private Location location;
 
     // The alert containing this occurrence.
     @ManyToOne
     @Cascade(CascadeType.SAVE_UPDATE)
-    @JoinColumn(name = "alert_id")
+    @JoinColumn(name = "alert_id", nullable = false)
     private Alert alert;
 
     // The database row creation date.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseOccurrenceReview.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseOccurrenceReview.java
@@ -38,12 +38,12 @@ public class DiseaseOccurrenceReview {
 
     // The expert.
     @ManyToOne
-    @JoinColumn(name = "expert_id")
+    @JoinColumn(name = "expert_id", nullable = false)
     private Expert expert;
 
     // The id of the disease occurrence.
     @ManyToOne
-    @JoinColumn(name = "disease_occurrence_id")
+    @JoinColumn(name = "disease_occurrence_id", nullable = false)
     private DiseaseOccurrence diseaseOccurrence;
 
     // The expert's response.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Expert.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Expert.java
@@ -28,19 +28,19 @@ public class Expert {
     private Integer id;
 
     // The expert's name.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     // The expert's email address.
-    @Column
+    @Column(nullable = false)
     private String email;
 
     // The expert's password
-    @Column(name = "hashed_password")
+    @Column(name = "hashed_password", nullable = false)
     private String password;
 
     // Whether the expert has administrative control.
-    @Column(name = "is_administrator")
+    @Column(name = "is_administrator", nullable = false)
     private boolean isAdministrator;
 
     // Whether the expert should be displayed in list on public site.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Feed.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Feed.java
@@ -26,12 +26,12 @@ public class Feed {
     private Integer id;
 
     // The name of this feed.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     // The provenance of this feed.
     @ManyToOne
-    @JoinColumn(name = "provenance_id")
+    @JoinColumn(name = "provenance_id", nullable = false)
     private Provenance provenance;
 
     // The weighting given to this feed.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/GeoName.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/GeoName.java
@@ -16,7 +16,7 @@ public class GeoName {
     private Integer id;
 
     // The GeoNames feature code for this ID.
-    @Column(name = "feature_code")
+    @Column(name = "feature_code", nullable = false)
     private String featureCode;
 
     public GeoName() {

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapCountry.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapCountry.java
@@ -28,7 +28,7 @@ public class HealthMapCountry {
     private Long id;
 
     // The country's name.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     // The corresponding SEEG countries.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapDisease.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapDisease.java
@@ -21,7 +21,7 @@ public class HealthMapDisease {
     private Long id;
 
     // The disease name.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     // The corresponding disease group as defined by SEEG.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Location.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Location.java
@@ -35,7 +35,7 @@ public class Location {
     private String name;
 
     // The location point. This can be a precise location, or the centroid of an administrative unit or country.
-    @Column
+    @Column(nullable = false)
     @Type(type = "org.hibernate.spatial.GeometryType")
     private Point geom;
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Provenance.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Provenance.java
@@ -26,7 +26,7 @@ public class Provenance {
     private Integer id;
 
     // The name of the provenance.
-    @Column
+    @Column(nullable = false)
     private String name;
 
     // The default weighting of feeds of this provenance. Used when creating a new feed.


### PR DESCRIPTION
Improve Hibernate queries by:
- adding "nullable = false" to not null columns (allows Hibernate to use inner joins instead of outer joins)
- adding "inner join fetch" to HQL to avoid multiple selects
