### PR TITLE
Convert all bigint database columns to integer.

### DIFF
--- a/db/tables.sql
+++ b/db/tables.sql
@@ -90,7 +90,7 @@ CREATE TABLE alert (
     publication_date timestamp NOT NULL,
     url varchar(2000) NOT NULL,
     summary text,
-    healthmap_alert_id bigint NOT NULL,
+    healthmap_alert_id integer NOT NULL,
     created_date timestamp NOT NULL DEFAULT LOCALTIMESTAMP
 );
 
@@ -165,7 +165,7 @@ CREATE TABLE feed (
     name varchar(100) NOT NULL,
     weighting double precision NOT NULL,
     language varchar(4),
-    healthmap_feed_id bigint,
+    healthmap_feed_id integer,
     created_date timestamp NOT NULL DEFAULT LOCALTIMESTAMP
 );
 
@@ -180,17 +180,17 @@ CREATE TABLE geonames_location_precision (
 );
 
 CREATE TABLE healthmap_country (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name varchar(100) NOT NULL
 );
 
 CREATE TABLE healthmap_country_country (
-    healthmap_country_id bigint NOT NULL,
+    healthmap_country_id integer NOT NULL,
     gaul_code integer NOT NULL
 );
 
 CREATE TABLE healthmap_disease (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name varchar(100) NOT NULL,
     disease_group_id integer,
     created_date timestamp NOT NULL DEFAULT LOCALTIMESTAMP
@@ -209,7 +209,7 @@ CREATE TABLE location (
     geoname_id integer,
     resolution_weighting double precision,
     created_date timestamp NOT NULL DEFAULT LOCALTIMESTAMP,
-    healthmap_country_id bigint,
+    healthmap_country_id integer,
     admin_unit_qc_gaul_code integer,
     admin_unit_global_gaul_code integer,
     admin_unit_tropical_gaul_code integer,

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/AlertDao.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/AlertDao.java
@@ -20,7 +20,7 @@ public interface AlertDao {
      * @param healthMapAlertId The HealthMap alert ID.
      * @return The alert, or null if not found.
      */
-    Alert getByHealthMapAlertId(Long healthMapAlertId);
+    Alert getByHealthMapAlertId(Integer healthMapAlertId);
 
     /**
      * Saves an alert.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/AlertDaoImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/AlertDaoImpl.java
@@ -22,7 +22,7 @@ public class AlertDaoImpl extends AbstractDao<Alert, Integer> implements AlertDa
      * @return The alert, or null if not found.
      */
     @Override
-    public Alert getByHealthMapAlertId(Long healthMapAlertId) {
+    public Alert getByHealthMapAlertId(Integer healthMapAlertId) {
         return uniqueResultNamedQuery("getAlertByHealthMapAlertId", "healthMapAlertId", healthMapAlertId);
     }
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapCountryDao.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapCountryDao.java
@@ -22,5 +22,5 @@ public interface HealthMapCountryDao {
      * @return The country, or null if not found.
      * @throws org.springframework.dao.DataAccessException if multiple countries with this name are found
      */
-    HealthMapCountry getById(Long id);
+    HealthMapCountry getById(Integer id);
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapCountryDaoImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapCountryDaoImpl.java
@@ -10,7 +10,7 @@ import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.HealthMapCountry;
  * Copyright (c) 2014 University of Oxford
  */
 @Repository
-public class HealthMapCountryDaoImpl extends AbstractDao<HealthMapCountry, Long> implements HealthMapCountryDao {
+public class HealthMapCountryDaoImpl extends AbstractDao<HealthMapCountry, Integer> implements HealthMapCountryDao {
     public HealthMapCountryDaoImpl(SessionFactory sessionFactory) {
         super(sessionFactory);
     }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapDiseaseDao.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapDiseaseDao.java
@@ -21,7 +21,7 @@ public interface HealthMapDiseaseDao {
      * @param id The ID.
      * @return The HealthMap disease, or null if not found.
      */
-    HealthMapDisease getById(Long id);
+    HealthMapDisease getById(Integer id);
 
     /**
      * Saves the specified HealthMap disease.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapDiseaseDaoImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapDiseaseDaoImpl.java
@@ -10,7 +10,7 @@ import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.HealthMapDisease;
  * Copyright (c) 2014 University of Oxford
  */
 @Repository
-public class HealthMapDiseaseDaoImpl extends AbstractDao<HealthMapDisease, Long> implements HealthMapDiseaseDao {
+public class HealthMapDiseaseDaoImpl extends AbstractDao<HealthMapDisease, Integer> implements HealthMapDiseaseDao {
     public HealthMapDiseaseDaoImpl(SessionFactory sessionFactory) {
         super(sessionFactory);
     }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Alert.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Alert.java
@@ -50,7 +50,7 @@ public class Alert {
 
     // The HealthMap alert ID (if this alert has originated in HealthMap).
     @Column(name = "healthmap_alert_id")
-    private Long healthMapAlertId;
+    private Integer healthMapAlertId;
 
     // The database row creation date.
     @Column(name = "created_date", insertable = false, updatable = false)
@@ -114,11 +114,11 @@ public class Alert {
         this.summary = summary;
     }
 
-    public Long getHealthMapAlertId() {
+    public Integer getHealthMapAlertId() {
         return healthMapAlertId;
     }
 
-    public void setHealthMapAlertId(Long healthMapAlertId) {
+    public void setHealthMapAlertId(Integer healthMapAlertId) {
         this.healthMapAlertId = healthMapAlertId;
     }
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Feed.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Feed.java
@@ -43,7 +43,7 @@ public class Feed {
 
     // The feed ID used for this provenance in HealthMap.
     @Column(name = "healthmap_feed_id")
-    private Long healthMapFeedId;
+    private Integer healthMapFeedId;
 
     // The database row creation date.
     @Column(name = "created_date", insertable = false, updatable = false)
@@ -58,7 +58,7 @@ public class Feed {
         this.name = name;
     }
 
-    public Feed(String name, Provenance provenance, double weighting, String language, Long healthMapFeedId) {
+    public Feed(String name, Provenance provenance, double weighting, String language, Integer healthMapFeedId) {
         this.name = name;
         this.provenance = provenance;
         this.weighting = weighting;
@@ -67,7 +67,7 @@ public class Feed {
     }
 
     public Feed(Integer id, String name, Provenance provenance, String language, double weighting,
-                Long healthMapFeedId) {
+                Integer healthMapFeedId) {
         this.id = id;
         this.name = name;
         this.provenance = provenance;
@@ -112,11 +112,11 @@ public class Feed {
         this.language = language;
     }
 
-    public Long getHealthMapFeedId() {
+    public Integer getHealthMapFeedId() {
         return healthMapFeedId;
     }
 
-    public void setHealthMapFeedId(Long healthMapFeedId) {
+    public void setHealthMapFeedId(Integer healthMapFeedId) {
         this.healthMapFeedId = healthMapFeedId;
     }
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapCountry.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapCountry.java
@@ -20,7 +20,7 @@ import java.util.Set;
 public class HealthMapCountry {
     // The country ID as used by HealthMap.
     @Id
-    private Long id;
+    private Integer id;
 
     // The country's name.
     @Column(nullable = false)
@@ -37,7 +37,7 @@ public class HealthMapCountry {
     public HealthMapCountry() {
     }
 
-    public HealthMapCountry(Long id, String name, Country... countries) {
+    public HealthMapCountry(Integer id, String name, Country... countries) {
         this.id = id;
         this.name = name;
         this.countries = new HashSet<>();
@@ -46,7 +46,7 @@ public class HealthMapCountry {
         }
     }
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapDisease.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/HealthMapDisease.java
@@ -18,7 +18,7 @@ import javax.persistence.*;
 public class HealthMapDisease {
     // The disease ID from HealthMap.
     @Id
-    private Long id;
+    private Integer id;
 
     // The disease name.
     @Column(nullable = false)
@@ -39,17 +39,17 @@ public class HealthMapDisease {
     public HealthMapDisease() {
     }
 
-    public HealthMapDisease(Long id, String name, DiseaseGroup diseaseGroup) {
+    public HealthMapDisease(Integer id, String name, DiseaseGroup diseaseGroup) {
         this.id = id;
         this.name = name;
         this.diseaseGroup = diseaseGroup;
     }
 
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Location.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/Location.java
@@ -60,7 +60,7 @@ public class Location {
 
     // The HealthMap country ID (if any).
     @Column(name = "healthmap_country_id")
-    private Long healthMapCountryId;
+    private Integer healthMapCountryId;
 
     // The GAUL code of the admin 1/2 unit assigned to the location during QC stage 1.
     @Column(name = "admin_unit_qc_gaul_code")
@@ -103,7 +103,7 @@ public class Location {
         this.name = name;
     }
 
-    public Location(String name, double x, double y, LocationPrecision precision, long healthMapCountryId) {
+    public Location(String name, double x, double y, LocationPrecision precision, int healthMapCountryId) {
         this(name, x, y, precision);
         this.healthMapCountryId = healthMapCountryId;
     }
@@ -144,11 +144,11 @@ public class Location {
         this.resolutionWeighting = resolutionWeighting;
     }
 
-    public Long getHealthMapCountryId() {
+    public Integer getHealthMapCountryId() {
         return healthMapCountryId;
     }
 
-    public void setHealthMapCountryId(Long healthMapCountryId) {
+    public void setHealthMapCountryId(Integer healthMapCountryId) {
         this.healthMapCountryId = healthMapCountryId;
     }
 

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/AlertService.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/AlertService.java
@@ -17,7 +17,7 @@ public interface AlertService {
      * @param healthMapAlertId The HealthMap alert ID.
      * @return The alert with this HealthMap alert ID, or null if not found.
      */
-    Alert getAlertByHealthMapAlertId(Long healthMapAlertId);
+    Alert getAlertByHealthMapAlertId(Integer healthMapAlertId);
 
     /**
      * Gets a list of alert feeds with the specified provenance name.

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/AlertServiceImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/AlertServiceImpl.java
@@ -31,7 +31,7 @@ public class AlertServiceImpl implements AlertService {
      * @return The alert with this HealthMap alert ID, or null if not found.
      */
     @Override
-    public Alert getAlertByHealthMapAlertId(Long healthMapAlertId) {
+    public Alert getAlertByHealthMapAlertId(Integer healthMapAlertId) {
         return alertDao.getByHealthMapAlertId(healthMapAlertId);
     }
 

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/AlertDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/AlertDaoTest.java
@@ -26,7 +26,7 @@ public class AlertDaoTest extends AbstractCommonSpringIntegrationTests {
         // Arrange
         Feed feed = feedDao.getById(1);
         DateTime publicationDate = new DateTime("2014-01-03T01:00:00-05:00");
-        long healthMapAlertId = 100L;
+        int healthMapAlertId = 100;
         String title = "Dengue/DHF update (15): Asia, Indian Ocean, Pacific";
         String summary = "This is a summary of the alert";
         String url = "http://www.promedmail.org/direct.php?id=20140217.2283261";

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DiseaseOccurrenceDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DiseaseOccurrenceDaoTest.java
@@ -244,7 +244,7 @@ public class DiseaseOccurrenceDaoTest extends AbstractCommonSpringIntegrationTes
     private Alert createAlert() {
         Feed feed = feedDao.getById(1);
         DateTime publicationDate = DateTime.now().minusDays(5);
-        long healthMapAlertId = 100L;
+        int healthMapAlertId = 100;
         String title = "Dengue/DHF update (15): Asia, Indian Ocean, Pacific";
         String summary = "This is a summary of the alert";
         String url = "http://www.promedmail.org/direct.php?id=20140217.2283261";

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DiseaseOccurrenceReviewDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DiseaseOccurrenceReviewDaoTest.java
@@ -117,7 +117,7 @@ public class DiseaseOccurrenceReviewDaoTest extends AbstractCommonSpringIntegrat
     private Alert createAlert() {
         Feed feed = feedDao.getById(1);
         DateTime publicationDate = DateTime.now().minusDays(5);
-        long healthMapAlertId = 100L;
+        int healthMapAlertId = 100;
         String title = "Dengue/DHF update (15): Asia, Indian Ocean, Pacific";
         String summary = "This is a summary of the alert";
         String url = "http://www.promedmail.org/direct.php?id=20140217.2283261";

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapCountryDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapCountryDaoTest.java
@@ -40,7 +40,7 @@ public class HealthMapCountryDaoTest extends AbstractCommonSpringIntegrationTest
     @Test
     public void getHealthMapCountryWithNoAssociatedSEEGCountries() {
         // Arrange
-        long id = 143;
+        int id = 143;
         String healthMapCountryName = "Maldives";
 
         // Act
@@ -57,7 +57,7 @@ public class HealthMapCountryDaoTest extends AbstractCommonSpringIntegrationTest
     @Test
     public void getHealthMapCountryWithOneAssociatedSEEGCountry() {
         // Arrange
-        long id = 28;
+        int id = 28;
         String healthMapCountryName = "Trinidad & Tobago";
 
         // Act
@@ -78,7 +78,7 @@ public class HealthMapCountryDaoTest extends AbstractCommonSpringIntegrationTest
     @Test
     public void getHealthMapCountryWithTwoAssociatedSEEGCountries() {
         // Arrange
-        long id = 104;
+        int id = 104;
         String healthMapCountryName = "Netherlands";
 
         // Act
@@ -103,7 +103,7 @@ public class HealthMapCountryDaoTest extends AbstractCommonSpringIntegrationTest
 
     @Test
     public void getHealthMapCountryByInvalidId() {
-        long id = 5000;
+        int id = 5000;
         HealthMapCountry healthMapCountry = healthMapCountryDao.getById(id);
         assertThat(healthMapCountry).isNull();
     }

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapDiseaseDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapDiseaseDaoTest.java
@@ -27,7 +27,7 @@ public class HealthMapDiseaseDaoTest extends AbstractCommonSpringIntegrationTest
         // Arrange
         String healthMapDiseaseName = "Test HealthMap disease";
         DiseaseGroup diseaseGroup = diseaseGroupDao.getById(16);
-        long healthMapDiseaseId = 10000;
+        int healthMapDiseaseId = 10000;
 
         HealthMapDisease disease = new HealthMapDisease();
         disease.setId(healthMapDiseaseId);
@@ -50,7 +50,7 @@ public class HealthMapDiseaseDaoTest extends AbstractCommonSpringIntegrationTest
     public void saveAndReloadHealthMapDiseaseWithoutGroup() {
         // Arrange
         String healthMapDiseaseName = "Test HealthMap disease";
-        long healthMapDiseaseId = 10000;
+        int healthMapDiseaseId = 10000;
 
         HealthMapDisease disease = new HealthMapDisease();
         disease.setId(healthMapDiseaseId);
@@ -69,7 +69,7 @@ public class HealthMapDiseaseDaoTest extends AbstractCommonSpringIntegrationTest
 
     @Test
     public void loadNonExistentHealthMapDisease() {
-        HealthMapDisease healthMapDisease = healthMapDiseaseDao.getById(-1L);
+        HealthMapDisease healthMapDisease = healthMapDiseaseDao.getById(-1);
         assertThat(healthMapDisease).isNull();
     }
 

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/LocationDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/LocationDaoTest.java
@@ -24,7 +24,7 @@ public class LocationDaoTest extends AbstractCommonSpringIntegrationTests {
     @Test
     public void saveAndReloadCountryLocation() {
         // Arrange
-        long healthMapCountryId = 1;
+        int healthMapCountryId = 1;
         String placeName = "Botswana";
         double x = -22.34284;
         double y = -24.6871;
@@ -58,7 +58,7 @@ public class LocationDaoTest extends AbstractCommonSpringIntegrationTests {
     @Test
     public void saveAndReloadAdmin1LocationByGeoNameId() {
         // Arrange
-        long healthMapCountryId = 2;
+        int healthMapCountryId = 2;
         String placeName = "England";
         double x = 52.88496;
         double y = -1.97703;
@@ -135,7 +135,7 @@ public class LocationDaoTest extends AbstractCommonSpringIntegrationTests {
     @Test
     public void saveAndReloadPreciseLocationByPoint() {
         // Arrange
-        long healthMapCountryId = 3;
+        int healthMapCountryId = 3;
         String placeName = "Oxford";
         double x = 51.75042;
         double y = -1.24759;

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/AlertServiceTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/AlertServiceTest.java
@@ -26,7 +26,7 @@ public class AlertServiceTest extends AbstractCommonSpringUnitTests {
     public void getAlertByHealthMapAlertId() {
         // Arrange
         Alert alert = new Alert();
-        long healthMapAlertId = 123L;
+        int healthMapAlertId = 123;
         when(alertDao.getByHealthMapAlertId(healthMapAlertId)).thenReturn(alert);
 
         // Act

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapAlertConverter.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapAlertConverter.java
@@ -70,7 +70,7 @@ public class HealthMapAlertConverter {
         Alert alert = null;
 
         // Try to find an alert with the given ID (if specified)
-        Long alertId = healthMapAlert.getAlertId();
+        Integer alertId = healthMapAlert.getAlertId();
         if (alertId != null) {
             alert = alertService.getAlertByHealthMapAlertId(alertId);
         } else {
@@ -84,7 +84,7 @@ public class HealthMapAlertConverter {
         return alert;
     }
 
-    private Alert createAlert(HealthMapAlert healthMapAlert, Long alertId) {
+    private Alert createAlert(HealthMapAlert healthMapAlert, Integer alertId) {
         Alert alert = new Alert();
         alert.setFeed(retrieveFeed(healthMapAlert));
         alert.setTitle(healthMapAlert.getSummary());

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLocationValidator.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLocationValidator.java
@@ -17,9 +17,9 @@ public class HealthMapLocationValidator {
             "HealthMap country \"%s\" (ID %d) does not exist in ABRAID database (place name \"%s\")";
 
     private HealthMapLocation location;
-    private Map<Long, HealthMapCountry> countryMap;
+    private Map<Integer, HealthMapCountry> countryMap;
 
-    public HealthMapLocationValidator(HealthMapLocation location, Map<Long, HealthMapCountry> countryMap) {
+    public HealthMapLocationValidator(HealthMapLocation location, Map<Integer, HealthMapCountry> countryMap) {
         this.location = location;
         this.countryMap = countryMap;
     }

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLookupData.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLookupData.java
@@ -21,9 +21,9 @@ public class HealthMapLookupData {
     private LocationService locationService;
     private DiseaseService diseaseService;
 
-    private Map<Long, HealthMapCountry> countryMap;
-    private Map<Long, HealthMapDisease> diseaseMap;
-    private Map<Long, Feed> feedMap;
+    private Map<Integer, HealthMapCountry> countryMap;
+    private Map<Integer, HealthMapDisease> diseaseMap;
+    private Map<Integer, Feed> feedMap;
     private Map<String, LocationPrecision> geoNamesMap;
     private Provenance healthMapProvenance;
 
@@ -38,7 +38,7 @@ public class HealthMapLookupData {
      * Gets a list of HealthMap countries, indexed by HealthMap country name.
      * @return A list of HealthMap countries, indexed by HealthMap country name.
      */
-    public Map<Long, HealthMapCountry> getCountryMap() {
+    public Map<Integer, HealthMapCountry> getCountryMap() {
         if (countryMap == null) {
             List<HealthMapCountry> countries = locationService.getAllHealthMapCountries();
             countryMap = index(countries, on(HealthMapCountry.class).getId());
@@ -50,7 +50,7 @@ public class HealthMapLookupData {
      * Gets a list of HealthMap diseases, indexed by HealthMap disease ID.
      * @return A list of HealthMap diseases, indexed by HealthMap disease ID.
      */
-    public Map<Long, HealthMapDisease> getDiseaseMap() {
+    public Map<Integer, HealthMapDisease> getDiseaseMap() {
         if (diseaseMap == null) {
             List<HealthMapDisease> diseases = diseaseService.getAllHealthMapDiseases();
             diseaseMap = index(diseases, on(HealthMapDisease.class).getId());
@@ -62,7 +62,7 @@ public class HealthMapLookupData {
      * Gets a list of HealthMap feeds, indexed by HealthMap feed ID.
      * @return A list of HealthMap feeds, indexed by HealthMap feed ID.
      */
-    public Map<Long, Feed> getFeedMap() {
+    public Map<Integer, Feed> getFeedMap() {
         if (feedMap == null) {
             List<Feed> feeds = alertService.getFeedsByProvenanceName(ProvenanceNames.HEALTHMAP);
             feedMap = index(feeds, on(Feed.class).getHealthMapFeedId());

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/domain/HealthMapAlert.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/domain/HealthMapAlert.java
@@ -20,10 +20,10 @@ public class HealthMapAlert {
 
     private String feed;
     @JsonProperty("feed_id")
-    private Long feedId;
+    private Integer feedId;
     private String disease;
     @JsonProperty("disease_id")
-    private Long diseaseId;
+    private Integer diseaseId;
     private String summary;
     private DateTime date;
     private String link;
@@ -37,7 +37,7 @@ public class HealthMapAlert {
     public HealthMapAlert() {
     }
 
-    public HealthMapAlert(String feed, Long feedId, String disease, Long diseaseId, String summary, DateTime date,
+    public HealthMapAlert(String feed, Integer feedId, String disease, Integer diseaseId, String summary, DateTime date,
                           String link, String description, String originalUrl, String feedLanguage) {
         this.feed = feed;
         this.feedId = feedId;
@@ -59,12 +59,12 @@ public class HealthMapAlert {
         this.feed = StringUtils.trimWhitespace(feed);
     }
 
-    public Long getFeedId() {
+    public Integer getFeedId() {
         return feedId;
     }
 
     public void setFeedId(String feedId) {
-        this.feedId = ParseUtils.parseLong(feedId);
+        this.feedId = ParseUtils.parseInteger(feedId);
     }
 
     public String getDisease() {
@@ -75,12 +75,12 @@ public class HealthMapAlert {
         this.disease = StringUtils.trimWhitespace(disease);
     }
 
-    public Long getDiseaseId() {
+    public Integer getDiseaseId() {
         return diseaseId;
     }
 
     public void setDiseaseId(String diseaseId) {
-        this.diseaseId = ParseUtils.parseLong(diseaseId);
+        this.diseaseId = ParseUtils.parseInteger(diseaseId);
     }
 
     public String getSummary() {
@@ -135,12 +135,12 @@ public class HealthMapAlert {
      * Extracts the alert ID from the link.
      * @return The alert ID, or null if it could not be extracted from the link.
      */
-    public Long getAlertId() {
-        Long alertId = null;
+    public Integer getAlertId() {
+        Integer alertId = null;
         if (StringUtils.hasText(link)) {
             Matcher regExMatcher = ALERT_ID_REGEXP.matcher(link.trim());
             while (regExMatcher.find() && regExMatcher.groupCount() == 1) {
-                alertId = ParseUtils.parseLong(regExMatcher.group(1));
+                alertId = ParseUtils.parseInteger(regExMatcher.group(1));
             }
         }
         return alertId;

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/domain/HealthMapLocation.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/domain/HealthMapLocation.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class HealthMapLocation {
     private String country;
     @JsonProperty("country_id")
-    private Long countryId;
+    private Integer countryId;
     @JsonProperty("place_name")
     private String placeName;
     @JsonProperty("lat")
@@ -28,12 +28,12 @@ public class HealthMapLocation {
 
     private List<HealthMapAlert> alerts;
 
-    public Long getCountryId() {
+    public Integer getCountryId() {
         return countryId;
     }
 
     public void setCountryId(String countryId) {
-        this.countryId = ParseUtils.parseLong(countryId);
+        this.countryId = ParseUtils.parseInteger(countryId);
     }
 
     public String getCountry() {

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/QCLookupData.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/QCLookupData.java
@@ -23,7 +23,7 @@ import static ch.lambdaj.Lambda.*;
 public class QCLookupData {
     private List<AdminUnitQC> adminUnits;
     private MultiPolygon landSeaBorders;
-    private Map<Long, MultiPolygon> healthMapCountryGeometryMap;
+    private Map<Integer, MultiPolygon> healthMapCountryGeometryMap;
 
     private LocationService locationService;
     private HealthMapLookupData healthMapLookupData;
@@ -62,9 +62,9 @@ public class QCLookupData {
      * If the HealthMap country has no associated geometries, it does not appear in the map.
      * @return A mapping as described above.
      */
-    public Map<Long, MultiPolygon> getHealthMapCountryGeometryMap() {
+    public Map<Integer, MultiPolygon> getHealthMapCountryGeometryMap() {
         if (healthMapCountryGeometryMap == null) {
-            Map<Long, HealthMapCountry> countryMap = healthMapLookupData.getCountryMap();
+            Map<Integer, HealthMapCountry> countryMap = healthMapLookupData.getCountryMap();
             healthMapCountryGeometryMap = new HashMap<>();
 
             for (HealthMapCountry country : countryMap.values()) {

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapAlertConverterTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapAlertConverterTest.java
@@ -29,13 +29,13 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = null;
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -78,13 +78,13 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "vi";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/doesnotcontainalertid";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -127,13 +127,13 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "zh";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -171,13 +171,13 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "zh";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -230,14 +230,14 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "zh";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String healthMapDiseaseNewName = "Test disease new name";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -278,16 +278,16 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = null;
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
-        Long existingDiseaseId = 2L;
+        int diseaseId = 1;
+        int feedId = 1;
+        int existingDiseaseId = 2;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String existingHealthMapDiseaseName = "Test existing disease";
         String diseaseGroupName = "NEW FROM HEALTHMAP: Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup existingDiseaseGroup = new DiseaseGroup();
@@ -330,11 +330,11 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "fr";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long feedId = 1L;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         Alert alert = new Alert();
@@ -366,13 +366,13 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "de";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         Alert alert = new Alert();
@@ -406,13 +406,13 @@ public class HealthMapAlertConverterTest {
         String feedLanguage = "de";
         String summary = "Test summary";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -453,13 +453,13 @@ public class HealthMapAlertConverterTest {
         String feedNewLanguage = "zh";
         String summary = "Test summary";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -499,13 +499,13 @@ public class HealthMapAlertConverterTest {
         String summary = "Test summary";
         String feedLanguage = "en";
         String originalUrl = "http://promedmail.org/direct.php?id=20140106.2154965";
-        Long diseaseId = 1L;
-        Long feedId = 1L;
+        int diseaseId = 1;
+        int feedId = 1;
         DateTime publicationDate = DateTime.now();
         String link = "http://healthmap.org/ln.php?2154965";
         String healthMapDiseaseName = "Test disease";
         String description = "Test description";
-        long healthMapAlertId = 2154965L;
+        int healthMapAlertId = 2154965;
 
         Location location = new Location();
         DiseaseGroup diseaseGroup = new DiseaseGroup();
@@ -532,7 +532,7 @@ public class HealthMapAlertConverterTest {
         assertThat(occurrence).isNull();
     }
 
-    private void mockOutGetAlertByID(AlertService alertService, long healthMapAlertId, Alert alert) {
+    private void mockOutGetAlertByID(AlertService alertService, int healthMapAlertId, Alert alert) {
         when(alertService.getAlertByHealthMapAlertId(healthMapAlertId)).thenReturn(alert);
     }
 
@@ -544,17 +544,17 @@ public class HealthMapAlertConverterTest {
     }
 
     private void mockOutGetFeed(HealthMapLookupData lookupData, Feed feed) {
-        Map<Long, Feed> feedMap = new HashMap<>();
+        Map<Integer, Feed> feedMap = new HashMap<>();
         if (feed != null) {
             feedMap.put(feed.getHealthMapFeedId(), feed);
         }
         when(lookupData.getFeedMap()).thenReturn(feedMap);
     }
 
-    private HealthMapDisease mockOutGetExistingHealthMapDisease(HealthMapLookupData lookupData, Long diseaseId,
+    private HealthMapDisease mockOutGetExistingHealthMapDisease(HealthMapLookupData lookupData, Integer diseaseId,
                                                     String healthMapDiseaseName, DiseaseGroup diseaseGroup) {
         HealthMapDisease healthMapDisease = new HealthMapDisease(diseaseId, healthMapDiseaseName, diseaseGroup);
-        Map<Long, HealthMapDisease> diseaseMap = new HashMap<>();
+        Map<Integer, HealthMapDisease> diseaseMap = new HashMap<>();
         diseaseMap.put(diseaseId, healthMapDisease);
         when(lookupData.getDiseaseMap()).thenReturn(diseaseMap);
         return healthMapDisease;

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLocationConverterTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLocationConverterTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.*;
 public class HealthMapLocationConverterTest {
     private static final String MAPPED_COUNTRY_NAME = "Argentina";
     private static final String UNMAPPED_COUNTRY_NAME = "Maldives";
-    private static final long MAPPED_COUNTRY_ID = 4L;
-    private static final long UNMAPPED_COUNTRY_ID = 143L;
+    private static final int MAPPED_COUNTRY_ID = 4;
+    private static final int UNMAPPED_COUNTRY_ID = 143;
 
     private HealthMapCountry mappedHealthMapCountry;
     private HealthMapCountry unMappedHealthMapCountry;
@@ -51,7 +51,7 @@ public class HealthMapLocationConverterTest {
     }
 
     private void setUpCountryMap() {
-        Map<Long, HealthMapCountry> countryMap = new HashMap<>();
+        Map<Integer, HealthMapCountry> countryMap = new HashMap<>();
         mappedHealthMapCountry = new HealthMapCountry(MAPPED_COUNTRY_ID, MAPPED_COUNTRY_NAME,
                 new Country(12, MAPPED_COUNTRY_NAME));
         unMappedHealthMapCountry = new HealthMapCountry(UNMAPPED_COUNTRY_ID, UNMAPPED_COUNTRY_NAME);

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLocationValidatorTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLocationValidatorTest.java
@@ -135,15 +135,15 @@ public class HealthMapLocationValidatorTest {
                 " (place name \"Test Place Name\")");
     }
 
-    private Map<Long, HealthMapCountry> getCountryMap() {
+    private Map<Integer, HealthMapCountry> getCountryMap() {
         Country country1 = new Country(167, "Mongolia");
         Country country2 = new Country(212, "Samoa");
-        HealthMapCountry healthMapCountry1 = new HealthMapCountry(1L, "Mongolia", country1);
-        HealthMapCountry healthMapCountry2 = new HealthMapCountry(2L, "Samoa", country2);
+        HealthMapCountry healthMapCountry1 = new HealthMapCountry(1, "Mongolia", country1);
+        HealthMapCountry healthMapCountry2 = new HealthMapCountry(2, "Samoa", country2);
 
-        Map<Long, HealthMapCountry> countryMap = new HashMap<>();
-        countryMap.put(1L, healthMapCountry1);
-        countryMap.put(2L, healthMapCountry2);
+        Map<Integer, HealthMapCountry> countryMap = new HashMap<>();
+        countryMap.put(1, healthMapCountry1);
+        countryMap.put(2, healthMapCountry2);
 
         return countryMap;
     }

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLookupDataTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/healthmap/HealthMapLookupDataTest.java
@@ -30,19 +30,19 @@ public class HealthMapLookupDataTest {
 
         Country country1 = new Country(1, "Test country 1");
         Country country2 = new Country(2, "Test country 2");
-        HealthMapCountry healthMapCountry1 = new HealthMapCountry(1L, "Test HealthMap country 1", country1);
-        HealthMapCountry healthMapCountry2 = new HealthMapCountry(2L, "Test HealthMap country 2", country2);
+        HealthMapCountry healthMapCountry1 = new HealthMapCountry(1, "Test HealthMap country 1", country1);
+        HealthMapCountry healthMapCountry2 = new HealthMapCountry(2, "Test HealthMap country 2", country2);
 
         List<HealthMapCountry> countries = Arrays.asList(healthMapCountry1, healthMapCountry2);
         when(locationService.getAllHealthMapCountries()).thenReturn(countries);
 
-        Map<Long, HealthMapCountry> expectedCountryMap = new HashMap<>();
-        expectedCountryMap.put(1L, healthMapCountry1);
-        expectedCountryMap.put(2L, healthMapCountry2);
+        Map<Integer, HealthMapCountry> expectedCountryMap = new HashMap<>();
+        expectedCountryMap.put(1, healthMapCountry1);
+        expectedCountryMap.put(2, healthMapCountry2);
 
         // Act
         HealthMapLookupData lookupData = new HealthMapLookupData(alertService, locationService, diseaseService);
-        Map<Long, HealthMapCountry> actualCountryMap = lookupData.getCountryMap();
+        Map<Integer, HealthMapCountry> actualCountryMap = lookupData.getCountryMap();
 
         // Assert
         assertThat(actualCountryMap).isEqualTo(expectedCountryMap);
@@ -57,19 +57,19 @@ public class HealthMapLookupDataTest {
 
         DiseaseGroup disease1 = new DiseaseGroup(1, null, "Test disease 1", DiseaseGroupType.CLUSTER);
         DiseaseGroup disease2 = new DiseaseGroup(2, null, "Test disease 2", DiseaseGroupType.CLUSTER);
-        HealthMapDisease healthMapDisease1 = new HealthMapDisease(1L, "Test HealthMap disease 1", disease1);
-        HealthMapDisease healthMapDisease2 = new HealthMapDisease(2L, "Test HealthMap disease 2", disease2);
+        HealthMapDisease healthMapDisease1 = new HealthMapDisease(1, "Test HealthMap disease 1", disease1);
+        HealthMapDisease healthMapDisease2 = new HealthMapDisease(2, "Test HealthMap disease 2", disease2);
 
         List<HealthMapDisease> diseases = Arrays.asList(healthMapDisease1, healthMapDisease2);
         when(diseaseService.getAllHealthMapDiseases()).thenReturn(diseases);
 
-        Map<Long, HealthMapDisease> expectedDiseaseMap = new HashMap<>();
-        expectedDiseaseMap.put(1L, healthMapDisease1);
-        expectedDiseaseMap.put(2L, healthMapDisease2);
+        Map<Integer, HealthMapDisease> expectedDiseaseMap = new HashMap<>();
+        expectedDiseaseMap.put(1, healthMapDisease1);
+        expectedDiseaseMap.put(2, healthMapDisease2);
 
         // Act
         HealthMapLookupData lookupData = new HealthMapLookupData(alertService, locationService, diseaseService);
-        Map<Long, HealthMapDisease> actualDiseaseMap = lookupData.getDiseaseMap();
+        Map<Integer, HealthMapDisease> actualDiseaseMap = lookupData.getDiseaseMap();
 
         // Assert
         assertThat(actualDiseaseMap).isEqualTo(expectedDiseaseMap);
@@ -83,19 +83,19 @@ public class HealthMapLookupDataTest {
         DiseaseService diseaseService = mock(DiseaseService.class);
 
         Provenance provenance = new Provenance(ProvenanceNames.HEALTHMAP);
-        Feed feed1 = new Feed(10, "Test feed 1", provenance, null, 1, 1L);
-        Feed feed2 = new Feed(20, "Test feed 2", provenance, "de", 1, 2L);
+        Feed feed1 = new Feed(10, "Test feed 1", provenance, null, 1, 1);
+        Feed feed2 = new Feed(20, "Test feed 2", provenance, "de", 1, 2);
 
         List<Feed> feeds = Arrays.asList(feed1, feed2);
         when(alertService.getFeedsByProvenanceName(ProvenanceNames.HEALTHMAP)).thenReturn(feeds);
 
-        Map<Long, Feed> expectedFeedMap = new HashMap<>();
-        expectedFeedMap.put(1L, feed1);
-        expectedFeedMap.put(2L, feed2);
+        Map<Integer, Feed> expectedFeedMap = new HashMap<>();
+        expectedFeedMap.put(1, feed1);
+        expectedFeedMap.put(2, feed2);
 
         // Act
         HealthMapLookupData lookupData = new HealthMapLookupData(alertService, locationService, diseaseService);
-        Map<Long, Feed> actualFeedMap = lookupData.getFeedMap();
+        Map<Integer, Feed> actualFeedMap = lookupData.getFeedMap();
 
         // Assert
         assertThat(actualFeedMap).isEqualTo(expectedFeedMap);

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/QCLookupDataTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/QCLookupDataTest.java
@@ -68,25 +68,25 @@ public class QCLookupDataTest {
 
         // Act
         QCLookupData lookupData = new QCLookupData(locationService, healthMapLookupData);
-        Map<Long, MultiPolygon> healthMapCountryGeometryMap = lookupData.getHealthMapCountryGeometryMap();
+        Map<Integer, MultiPolygon> healthMapCountryGeometryMap = lookupData.getHealthMapCountryGeometryMap();
 
         // Assert
         assertThat(healthMapCountryGeometryMap).hasSize(2);
-        assertThat(healthMapCountryGeometryMap.get(1L)).isNotNull();
-        assertThat(healthMapCountryGeometryMap.get(2L)).isNull();
-        assertThat(healthMapCountryGeometryMap.get(3L)).isNotNull();
-        assertThat(healthMapCountryGeometryMap.get(1L).equals(expectedGeometry1)).isTrue();
-        assertThat(healthMapCountryGeometryMap.get(3L).equals(expectedGeometry2)).isTrue();
+        assertThat(healthMapCountryGeometryMap.get(1)).isNotNull();
+        assertThat(healthMapCountryGeometryMap.get(2)).isNull();
+        assertThat(healthMapCountryGeometryMap.get(3)).isNotNull();
+        assertThat(healthMapCountryGeometryMap.get(1).equals(expectedGeometry1)).isTrue();
+        assertThat(healthMapCountryGeometryMap.get(3).equals(expectedGeometry2)).isTrue();
     }
 
-    private Map<Long, HealthMapCountry> getCountryMap() {
+    private Map<Integer, HealthMapCountry> getCountryMap() {
         Country country1 = new Country(1, "Triangle", GeometryUtils.createMultiPolygon(getTriangle()));
         Country country2 = new Country(2, "Square", GeometryUtils.createMultiPolygon(getSquare()));
         Country country3 = new Country(3, "Five-pointed", GeometryUtils.createMultiPolygon(getFivePointedPolygon()));
         List<HealthMapCountry> healthMapCountries = Arrays.asList(
-                new HealthMapCountry(1L, "HealthMap country 1", country1),
-                new HealthMapCountry(2L, "HealthMap country 2"),
-                new HealthMapCountry(3L, "HealthMap country 3", country2, country3));
+                new HealthMapCountry(1, "HealthMap country 1", country1),
+                new HealthMapCountry(2, "HealthMap country 2"),
+                new HealthMapCountry(3, "HealthMap country 3", country2, country3));
         return index(healthMapCountries, on(HealthMapCountry.class).getId());
     }
 

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/QCManagerIntegrationTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/QCManagerIntegrationTest.java
@@ -20,7 +20,7 @@ public class QCManagerIntegrationTest extends AbstractDataAcquisitionSpringInteg
     @Test
     public void stage1AndStage2NotRunWhenLocationPrecisionIsCountryAndStage3Passes() {
         // Arrange
-        long japanId = 156L;
+        int japanId = 156;
         Location location = new Location("Japan", 138.47861, 36.09854, LocationPrecision.COUNTRY, japanId);
 
         // Act
@@ -53,7 +53,7 @@ public class QCManagerIntegrationTest extends AbstractDataAcquisitionSpringInteg
     @Test
     public void passesStage1AndStage2AndStage3() {
         // Arrange
-        long mexicoId = 14L;
+        int mexicoId = 14;
         Location location = new Location("Estado de México, Mexico", -99.4922, 19.3318, LocationPrecision.ADMIN1,
                 mexicoId);
 
@@ -71,7 +71,7 @@ public class QCManagerIntegrationTest extends AbstractDataAcquisitionSpringInteg
     @Test
     public void failsStage1() {
         // Arrange
-        long vietnamId = 152L;
+        int vietnamId = 152;
         Location location = new Location("Huyện Cai Lậy, Tiền Giang, Vietnam", 108.69807, 7.90055,
                 LocationPrecision.ADMIN2, vietnamId);
 
@@ -88,7 +88,7 @@ public class QCManagerIntegrationTest extends AbstractDataAcquisitionSpringInteg
     @Test
     public void passesStage1ButFailsStage2() {
         // Arrange
-        long indonesiaId = 184L;
+        int indonesiaId = 184;
         Location location = new Location("Central Sulawesi, Indonesia", 121, -1, LocationPrecision.ADMIN1, indonesiaId);
 
         // Act
@@ -105,7 +105,7 @@ public class QCManagerIntegrationTest extends AbstractDataAcquisitionSpringInteg
     @Test
     public void passesStage1AndStage2ButFailsStage3() {
         // Arrange
-        long usId = 106L;
+        int usId = 106;
         Location location = new Location("Door County, Wisconsin, United States", -87.3001, 44.91666,
                 LocationPrecision.ADMIN2, usId);
 
@@ -140,7 +140,7 @@ public class QCManagerIntegrationTest extends AbstractDataAcquisitionSpringInteg
     @Test
     public void passesStage3IfHealthMapCountryHasNoGeometries() {
         // Arrange
-        long maldivesId = 143;
+        int maldivesId = 143;
         Location location = new Location("Maldives", 73.46564, 5.84270, LocationPrecision.COUNTRY, maldivesId);
 
         // Act


### PR DESCRIPTION
And refactor the Java code accordingly.

The columns were originally bigint due to misinterpreting HealthMap's MySQL data type "int(11)" (this does NOT mean an integer with up to 11 significant figures, the 11 refers to how the integer is displayed).
