### PR TITLE
Quick fix for new artefact

### DIFF
--- a/src/PublicSite/web/js/app/SelectedLayerViewModel.js
+++ b/src/PublicSite/web/js/app/SelectedLayerViewModel.js
@@ -22,6 +22,12 @@ define(["ko"], function (ko) {
             this.children = children;
         };
 
+        // Return the first validator disease group of the expert's "Disease Interests", if they have any registered.
+        // Otherwise, return the first disease set of the "All Other Diseases" list.
+        var initialSelectedDiseaseSet = function () {
+            return diseaseInterests.length !== 0 ? self.groups[0].children[0] : self.groups[1].children[0];
+        };
+
         // View Model State
         self.validationTypes = [DISEASE_OCCURRENCES, DISEASE_EXTENT];
         self.selectedType = ko.observable(self.validationTypes[0]);
@@ -29,7 +35,7 @@ define(["ko"], function (ko) {
             new Group("Your Disease Interests", diseaseInterests),
             new Group("Other Diseases", allOtherDiseases)
         ];
-        self.selectedDiseaseSet = ko.observable(self.groups[0].children[0]);
+        self.selectedDiseaseSet = ko.observable(initialSelectedDiseaseSet());
         self.selectedDisease = ko.observable(self.selectedDiseaseSet().diseaseGroups[0]);
 
         // View State

--- a/src/PublicSite/web/js/app/spec/SelectedLayerViewModelSpec.js
+++ b/src/PublicSite/web/js/app/spec/SelectedLayerViewModelSpec.js
@@ -8,7 +8,7 @@ define([
 ], function (SelectedLayerViewModel, ko, _) {
     "use strict";
 
-    describe("The selected layer view model", function () {
+    describe("The 'selected layer' view model", function () {
         var diseaseInterests = [ { name: "dengue", diseaseGroups: [ { name: "dengue" } ] } ];
         var vm = {};
         beforeEach(function () {
@@ -56,8 +56,18 @@ define([
                 expect(vm.selectedDiseaseSet).toBeObservable();
             });
 
-            it("is initially the first disease interest", function () {
-                expect(vm.selectedDiseaseSet()).toBe(diseaseInterests[0]);
+            describe("is initially", function () {
+                it("the first disease group from the 'Disease Interests' list, if the list exists", function () {
+                    expect(vm.selectedDiseaseSet()).toBe(diseaseInterests[0]);
+                });
+
+                it("or the first disease group from the 'Other Diseases' list, otherwise", function () {
+                    var diseaseInterests = [];
+                    var allOtherDiseases = [ {name: "ascariasis", diseaseGroups: [ { name: "ascariasis" } ] } ];
+                    vm = new SelectedLayerViewModel(diseaseInterests, allOtherDiseases);
+
+                    expect(vm.selectedDiseaseSet()).toBe(allOtherDiseases[0]);
+                });
             });
 
             it("fires the 'layers-changed' event when its value changes, for 'disease occurrences'", function () {


### PR DESCRIPTION
Add case for when expert has no 'Disease Interests': initial 'selected disease set' is instead the first disease group from 'All Other Diseases' list.
