### PR TITLE
Fix rounding error in snapping points to border

### DIFF
--- a/src/Common/ivy.xml
+++ b/src/Common/ivy.xml
@@ -53,7 +53,7 @@
         &ivy-project-dependencies;
 
         <!-- Geometry utilities -->
-        <dependency org="com.vividsolutions" name="jts" rev="1.8" conf="external->default" />
+        <dependency org="com.vividsolutions" name="jts" rev="1.13" conf="external->default" />
         <dependency org="org.geotools" name="gt-api" rev="11.0" conf="external->default" />
         <dependency org="org.geotools" name="gt-referencing" rev="11.0" conf="external->default" />
         <dependency org="org.geotools" name="gt-opengis" rev="11.0" conf="external->default" />

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/util/GeometryUtils.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/util/GeometryUtils.java
@@ -17,7 +17,10 @@ public final class GeometryUtils {
     public static final int SRID_FOR_WGS_84 = 4326;
 
     // Enforces co-ordinate precision to 5 decimal places
-    private static final PrecisionModel PRECISION_MODEL = new PrecisionModel(100000);
+    private static final double PRECISION_DECIMAL_PLACES = 5;
+    private static final PrecisionModel PRECISION_MODEL = new PrecisionModel(Math.pow(10, PRECISION_DECIMAL_PLACES));
+    private static final double[] PRECISION_ADJUSTMENTS =
+            { 0, -Math.pow(10, -PRECISION_DECIMAL_PLACES), Math.pow(10, -PRECISION_DECIMAL_PLACES) };
 
     // Constructs a geometry using the above precision and the preferred SRID.
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(PRECISION_MODEL, SRID_FOR_WGS_84);
@@ -35,15 +38,28 @@ public final class GeometryUtils {
      * @return A point.
      */
     public static Point createPoint(double x, double y) {
-        return createPoint(new Coordinate(x, y));
+        Coordinate coordinate = new Coordinate(x, y);
+        PRECISION_MODEL.makePrecise(coordinate);
+        return GEOMETRY_FACTORY.createPoint(coordinate);
     }
 
     /**
-     * Creates a polygon from a list of co-ordinates.
+     * Creates a polygon from a list of co-ordinates. The co-ordinates are made precise.
      * @param xOrY The co-ordinates in the form x1, y1, x2, y2, ...
      * @return A polygon.
      */
     public static Polygon createPolygon(double... xOrY) {
+        return createPolygon(true, xOrY);
+    }
+
+    /**
+     * Creates a polygon from a list of co-ordinates.
+     * @param makePrecise True if the co-ordinates should be made precise according to the system default precision
+     * model, otherwise false.
+     * @param xOrY The co-ordinates in the form x1, y1, x2, y2, ...
+     * @return A polygon.
+     */
+    public static Polygon createPolygon(boolean makePrecise, double... xOrY) {
         if (xOrY.length % 2 > 0) {
             throw new IllegalArgumentException("Number of parameters must be even");
         }
@@ -51,7 +67,9 @@ public final class GeometryUtils {
         Coordinate[] coordinates = new Coordinate[xOrY.length / 2];
         for (int i = 0; i < xOrY.length; i += 2) {
             Coordinate coordinate = new Coordinate(xOrY[i], xOrY[i + 1]);
-            PRECISION_MODEL.makePrecise(coordinate);
+            if (makePrecise) {
+                PRECISION_MODEL.makePrecise(coordinate);
+            }
             coordinates[i / 2] = coordinate;
         }
 
@@ -122,18 +140,34 @@ public final class GeometryUtils {
 
     /**
      * Finds the closest point on the geometry to the specified point. If the specified point is within the geometry,
-     * it returns a point that is equal to the specified point.
+     * it returns a point that is equal to the specified point. If a closest point cannot be found, it returns null.
      * @param geometry The geometry.
      * @param point The specified point.
-     * @return The closest point, or the specified point if it is within the geometry.
+     * @return The closest point, or the specified point if it is within the geometry, or null if a closest point
+     * cannot be found.
      */
     public static Point findClosestPointOnGeometry(Geometry geometry, Point point) {
-        Coordinate[] coordinates = DistanceOp.closestPoints(geometry, point);
-        return createPoint(coordinates[0]);
+        Coordinate[] coordinates = DistanceOp.nearestPoints(geometry, point);
+
+        // After the closest point is rounded, it may no longer lie in the geometry. So make tiny adjustments to the
+        // coordinates until it does. By default the original point is returned (this is because the first adjustment
+        // involves adding 0 to both x and y).
+        for (double xAdjustment : PRECISION_ADJUSTMENTS) {
+            for (double yAdjustment : PRECISION_ADJUSTMENTS) {
+                Point closestPoint = createPoint(coordinates[0].x + xAdjustment, coordinates[0].y + yAdjustment);
+                if (contains(geometry, closestPoint)) {
+                    return closestPoint;
+                }
+            }
+        }
+
+        // We cannot find a closest point that conforms to our precision model, so return null
+        return null;
     }
 
-    private static Point createPoint(Coordinate coordinate) {
-        PRECISION_MODEL.makePrecise(coordinate);
-        return GEOMETRY_FACTORY.createPoint(coordinate);
+    private static boolean contains(Geometry geometry, Point point) {
+        // Ideally we would use Geometry.intersects() instead, but it sometimes reports "side location conflict" errors
+        Coordinate[] coordinate = DistanceOp.nearestPoints(geometry, point);
+        return point.getCoordinate().equals(coordinate[0]);
     }
 }

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/util/GeometryUtilsTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/util/GeometryUtilsTest.java
@@ -302,6 +302,39 @@ public class GeometryUtilsTest {
         assertThat(closestPoint.equalsExact(expectedClosestPoint)).isTrue();
     }
 
+    @Test
+    public void findClosestPointOnGeometrySnapsOutsidePointWithCorrectRounding() {
+        // Arrange
+        Geometry geometry = GeometryUtils.createPolygon(false, 10.000003, 10.000002, 10, 20, 20, 20, 20, 10,
+                10.000003, 10.000002);
+        Point point = GeometryUtils.createPoint(9, 9);
+        Point expectedCorrectClosestPoint = GeometryUtils.createPoint(10.00001, 10.00001);
+        Point expectedIncorrectClosestPoint = GeometryUtils.createPoint(10, 10);
+        assertThat(geometry.intersects(expectedCorrectClosestPoint)).isTrue();
+        assertThat(geometry.intersects(expectedIncorrectClosestPoint)).isFalse();
+
+        // Act
+        Point closestPoint = GeometryUtils.findClosestPointOnGeometry(geometry, point);
+
+        // Assert
+        assertThat(closestPoint.equalsExact(expectedCorrectClosestPoint)).isTrue();
+        assertThat(closestPoint.equalsExact(expectedIncorrectClosestPoint)).isFalse();
+    }
+
+    @Test
+    public void findClosestPointOnGeometryReturnsNullIfClosestPointCannotBeFound() {
+        // Arrange
+        Geometry geometry = GeometryUtils.createPolygon(false, 10.000003, 10.000003, 10.000003, 10.000006,
+                10.000006, 10.000006, 10.000006, 10.000003, 10.000003, 10.000003);
+        Point point = GeometryUtils.createPoint(9, 9);
+
+        // Act
+        Point closestPoint = GeometryUtils.findClosestPointOnGeometry(geometry, point);
+
+        // Assert
+        assertThat(closestPoint).isNull();
+    }
+
     // Asserted exception is in the @Test annotation - cannot use catchException() for static methods
     @Test(expected = IllegalArgumentException.class)
     public void createPolygonThrowsExceptionIfNumberParametersIsOdd() {

--- a/src/DataAcquisition/ivy.xml
+++ b/src/DataAcquisition/ivy.xml
@@ -21,7 +21,7 @@
         <dependency org="org.springframework" name="spring-orm" rev="4.0.1.RELEASE" conf="external->default"/>
         <dependency org="org.glassfish.jersey.core" name="jersey-client" rev="2.6" conf="external->default"/>
         <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.3.1" conf="external->default" />
-        <dependency org="com.vividsolutions" name="jts" rev="1.8" conf="external->default" />
+        <dependency org="com.vividsolutions" name="jts" rev="1.13" conf="external->default" />
 
         <!-- Internal -->
         <dependency org="uk.ac.ox.zoo.seeg.abraid.mp" name="common" changing="true" rev="${repository.version}" conf="build"/>

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/PostQCManager.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/PostQCManager.java
@@ -25,6 +25,7 @@ public class PostQCManager {
     public void runPostQCProcesses(Location location) {
         assignDiseaseExtentAdminUnits(location);
         assignCountry(location);
+        failQCIfAnyGaulCodesAreMissing(location);
         setResolutionWeighting(location);
     }
 
@@ -58,6 +59,14 @@ public class PostQCManager {
     private void assignCountry(Location location) {
         Integer countryGaulCode = locationService.findCountryThatContainsPoint(location.getGeom());
         location.setCountryGaulCode(countryGaulCode);
+    }
+
+    private void failQCIfAnyGaulCodesAreMissing(Location location) {
+        // A sanity check - this should only happen if the shapefiles are inconsistent or the snapping routines fail
+        if (location.getAdminUnitGlobalGaulCode() == null || location.getAdminUnitTropicalGaulCode() == null ||
+                location.getCountryGaulCode() == null) {
+            location.setHasPassedQc(false);
+        }
     }
 
     private void setResolutionWeighting(Location location) {

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/PostQCManagerIntegrationTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/qc/PostQCManagerIntegrationTest.java
@@ -82,8 +82,10 @@ public class PostQCManagerIntegrationTest extends AbstractDataAcquisitionSpringI
     @Test
     public void doesNotFindAdminUnitsIfOutsideGeometry() {
         Location location = new Location(-40, 50, LocationPrecision.PRECISE);
+        location.setHasPassedQc(true);
         postQCManager.runPostQCProcesses(location);
         assertThat(location.getAdminUnitGlobalGaulCode()).isNull();
         assertThat(location.getAdminUnitTropicalGaulCode()).isNull();
+        assertThat(location.hasPassedQc()).isFalse();
     }
 }

--- a/src/ModelWrapper/ivy.xml
+++ b/src/ModelWrapper/ivy.xml
@@ -27,7 +27,7 @@
         <dependency org="net.lingala.zip4j" name="zip4j" rev="1.3.2" conf="external->default" />
 
         <!-- Geo -->
-        <dependency org="com.vividsolutions" name="jts" rev="1.8" conf="external->default" />
+        <dependency org="com.vividsolutions" name="jts" rev="1.13" conf="external->default" />
         <dependency org="org.geotools" name="gt-api" rev="11.0" conf="external->default" />
         <dependency org="org.geotools" name="gt-main" rev="11.0" conf="external->default" />
         <dependency org="org.geotools" name="gt-referencing" rev="11.0" conf="external->default" />

--- a/src/PublicSite/ivy.xml
+++ b/src/PublicSite/ivy.xml
@@ -20,7 +20,7 @@
         <!-- External -->
         <dependency org="org.freemarker" name="freemarker" rev="2.3.20" conf="external->default"/>
         <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
-        <dependency org="com.vividsolutions" name="jts" rev="1.8" conf="external->default" />
+        <dependency org="com.vividsolutions" name="jts" rev="1.13" conf="external->default" />
         <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.3.1" conf="external->default" />
         <dependency org="com.fasterxml.jackson.datatype" name="jackson-datatype-joda" rev="2.3.1" conf="external->default" />
 


### PR DESCRIPTION
- Fix snapping points to GAUL borders when rounding error takes the point slightly outside of the polygon.
- Ensure QC fails if any location GAUL codes are missing.
- Upgrade JTS to latest version throughout source code.
