### PR TITLE
Set database character set to UTF-8

### DIFF
--- a/db/create_database.sql
+++ b/db/create_database.sql
@@ -13,7 +13,7 @@ SET client_min_messages TO WARNING;
 
 -- Drop and create the database
 DROP DATABASE IF EXISTS :database_name;
-CREATE DATABASE :database_name;
+CREATE DATABASE :database_name ENCODING 'UTF8';
 
 -- Change context to the newly-created database
 \c :database_name


### PR DESCRIPTION
This came to light because the default character set of the new blade servers is US-ASCII (unlike the virtual machine which is UTF-8).
