### PR TITLE
Bug in refactored Data Acquisition

### DIFF
--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapLocationConverter.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapLocationConverter.java
@@ -88,13 +88,16 @@ public class HealthMapLocationConverter {
             location.setHealthMapCountryId(healthMapCountry.getId());
             location.setGeom(healthMapLocation.getLongitude(), healthMapLocation.getLatitude());
             location.setName(healthMapLocation.getPlaceName());
-            addPrecision(healthMapLocation, location);
+            if (!addPrecision(healthMapLocation, location)) {
+                // If precision could not be added, return null (i.e. location could not be converted)
+                return null;
+            }
         }
 
         return location;
     }
 
-    private void addPrecision(HealthMapLocation healthMapLocation, Location location) {
+    private boolean addPrecision(HealthMapLocation healthMapLocation, Location location) {
         Integer geoNameId = healthMapLocation.getGeoNameId();
 
         if (geoNameId != null) {
@@ -106,6 +109,8 @@ public class HealthMapLocationConverter {
             // precision supplied in HealthMap's place_basic_type field.
             addPrecisionUsingHealthMapPlaceBasicType(location, healthMapLocation);
         }
+
+        return (location.getPrecision() != null);
     }
 
     private void addPrecisionUsingGeoNames(Location location, int geoNameId) {

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapLocationConverterTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapLocationConverterTest.java
@@ -289,8 +289,7 @@ public class HealthMapLocationConverterTest {
         Location location = converter.convert(healthMapLocation);
 
         // Assert
-        assertThat(location.getGeoNameId()).isNull();
-        assertThat(location.getPrecision()).isNull();
+        assertThat(location).isNull();
     }
 
     private HealthMapLocation createDefaultHealthMapLocation() {


### PR DESCRIPTION
Threw an exception if the HealthMap data did not provide a place_basic_type. Discovered when acquiring the entire HealthMap dataset. Bug didn't exist before the data acquisition / data manager split.
