### PR TITLE
Fix map projection

### DIFF
--- a/src/PublicSite/web/js/app/datavalidation/MapView.js
+++ b/src/PublicSite/web/js/app/datavalidation/MapView.js
@@ -35,7 +35,8 @@ define([
             maxZoom: 7,
             minZoom: 3,
             animate: true,
-            bounceAtZoomLimits: false
+            bounceAtZoomLimits: false,
+            crs: L.CRS.EPSG4326
         }).fitWorld();
 
         // Add the simplified shapefile base layer with WMS GET request


### PR DESCRIPTION
We should be using WGS84 (on Data Validator and Atlas) which is EPSG4326. Layers are configured as 4326 in GeoServer, but Leaflet's map default setting was reprojecting them to 3857.

Any layer (WMS, JSON etc) added to map takes the map's CRS as default, so the parameter does not need to be specified again, and should not be overridden.
