### PR TITLE
Disease  extent generation transaction bug

### DIFF
--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/ModelRunWorkflowServiceImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/ModelRunWorkflowServiceImpl.java
@@ -146,7 +146,6 @@ public class ModelRunWorkflowServiceImpl implements ModelRunWorkflowService {
         diseaseExtentGenerator.generateDiseaseExtent(diseaseGroup, null, true);
     }
 
-    @Transactional(rollbackFor = Exception.class)
     private void prepareForAndRequestModelRun(int diseaseGroupId, DateTime batchStartDate, DateTime batchEndDate)
             throws ModelRunRequesterException {
         DiseaseGroup diseaseGroup = diseaseService.getDiseaseGroupById(diseaseGroupId);

--- a/src/PublicSite/src/uk/ac/ox/zoo/seeg/abraid/mp/publicsite/web/admin/AdminDiseaseGroupController.java
+++ b/src/PublicSite/src/uk/ac/ox/zoo/seeg/abraid/mp/publicsite/web/admin/AdminDiseaseGroupController.java
@@ -154,6 +154,7 @@ public class AdminDiseaseGroupController extends AbstractController {
             method = RequestMethod.POST,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
+    @Transactional(rollbackFor = Exception.class)
     public ResponseEntity<String> requestModelRun(@PathVariable int diseaseGroupId, String batchStartDate,
                                                   String batchEndDate, boolean useGoldStandardOccurrences) {
         try {


### PR DESCRIPTION
Ensure that DiseaseGroup object in transaction cache when generating a disease extent, as it will be saved to update the "last_extent_generation_date".

Four possible scenarios:
- Manual disease extent generation (new transactional in PublicSite AdminDiseaseGroupController)
- Manual model run request (new transactional in PublicSite AdminDiseaseGroupController)
- Automatic model run request (already transactional in DataManager ModelRunManager)
- Automatic disease extent generation  (already transactional in ModelOutputHandler DiseaseExtentGenerationHandler)

2 potential solutions (see each commit). **For discussion**.
