### PR TITLE
Fix python bug

### DIFF
--- a/python/machine_weighting_predictor.py
+++ b/python/machine_weighting_predictor.py
@@ -51,6 +51,7 @@ def predict(disease_group_id):
         try:
             filename = _get_pickled_predictor_filename(disease_group_id)
             predictor = joblib.load(filename)
+            PREDICTORS[disease_group_id] = predictor
         except IOError as e:
             return ('Unable to load predictor for disease group - ' + e.strerror, 400)
 
@@ -61,6 +62,7 @@ def predict(disease_group_id):
         try:
             filename = _get_pickled_feed_classes_filename(disease_group_id)
             feed_classes = joblib.load(filename)
+            FEED_CLASSES[disease_group_id] = feed_classes
         except IOError as e:
             return ('Unable to load feeds for disease group - ' + e.strerror, 400)
 
@@ -111,7 +113,7 @@ def _save_predictor(disease_group_id, predictor):
     PREDICTORS[disease_group_id] = predictor
     try:
         joblib.dump(predictor, _get_pickled_predictor_filename(disease_group_id))
-        joblib.dump(FEED_CLASSES, _get_pickled_feed_classes_filename(disease_group_id))
+        joblib.dump(FEED_CLASSES[disease_group_id], _get_pickled_feed_classes_filename(disease_group_id))
     except IOError as e:
         print 'Unable to save pickle - ' + e.strerror
 


### PR DESCRIPTION
Save feed_classes as individual pickle rather than combined dictionary for all diseases

Make sure predictors and feed_classes are only reloaded once, and saved to local store
