### PR TITLE
Fix broken ftl template

### DIFF
--- a/src/PublicSite/web/WEB-INF/freemarker/layout/common.ftl
+++ b/src/PublicSite/web/WEB-INF/freemarker/layout/common.ftl
@@ -21,11 +21,7 @@
 </#macro>
 
 <#macro minimalPage title endOfHead="">
-    <#assign publicSiteEndOfHeadContent>
-        <link rel="stylesheet" href="<@spring.url "/js/shared/lib/jquery.cookiecuttr.css" />">
-        ${endOfHead}
-    </#assign>
-    <@page title=title endOfHead=publicSiteEndOfHeadContent mainjs="/js/kickstart/minimal" includeNavBar=false includeFooter=false>
+    <@page title=title endOfHead=endOfHead mainjs="/js/kickstart/minimal" includeNavBar=false includeFooter=false>
         <#nested/>
     </@page>
 </#macro>


### PR DESCRIPTION
Remove redundant cookie cutter css reference (and hence remove requirement for sprint.ftl to be loaded)
Fixes spread table page