### PR TITLE
1.0.6-hotfix1

### DIFF
--- a/db/migrations/1505191425__add_new_hm_subdiseases.sql
+++ b/db/migrations/1505191425__add_new_hm_subdiseases.sql
@@ -1,0 +1,15 @@
+-- Add new healthmap subdiseases.
+-- Copyright (c) 2015 University of Oxford
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'lnewcut', (SELECT id FROM disease_group WHERE abbreviation='nwcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'loldcut', (SELECT id FROM disease_group WHERE abbreviation='owcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'lcutnew', (SELECT id FROM disease_group WHERE abbreviation='nwcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'lcutold', (SELECT id FROM disease_group WHERE abbreviation='owcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'inewcut', (SELECT id FROM disease_group WHERE abbreviation='nwcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'ioldcut', (SELECT id FROM disease_group WHERE abbreviation='owcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'icutnew', (SELECT id FROM disease_group WHERE abbreviation='nwcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'icutold', (SELECT id FROM disease_group WHERE abbreviation='owcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'inew', (SELECT id FROM disease_group WHERE abbreviation='nwcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'iold', (SELECT id FROM disease_group WHERE abbreviation='owcl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'ivisceral', (SELECT id FROM disease_group WHERE abbreviation='vl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'icut', (SELECT id FROM disease_group WHERE abbreviation='cl'));
+INSERT INTO healthmap_subdisease (healthmap_disease_id, name, disease_group_id) VALUES ((SELECT id FROM healthmap_disease WHERE name='Leishmaniasis'), 'ivisc', (SELECT id FROM disease_group WHERE abbreviation='vl'));

--- a/src/.idea/runConfigurations/DM.xml
+++ b/src/.idea/runConfigurations/DM.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DM" type="Application" factoryName="Application" show_console_on_std_out="true" show_console_on_std_err="true">
+    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+    <option name="MAIN_CLASS_NAME" value="uk.ac.ox.zoo.seeg.abraid.mp.datamanager.Main" />
+    <option name="VM_PARAMETERS" value="-XX:MaxPermSize=256M -Dlog4j.configuration=file:DataManager\src\uk\ac\ox\zoo\seeg\abraid\mp\datamanager\log4j.properties" />
+    <option name="PROGRAM_PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" value="" />
+    <option name="ENABLE_SWING_INSPECTOR" value="false" />
+    <option name="ENV_VARIABLES" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <module name="DataManager" />
+    <envs />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="" />
+      <option name="TRANSPORT" value="0" />
+      <option name="LOCAL" value="true" />
+    </RunnerSettings>
+    <RunnerSettings RunnerId="Run" />
+    <ConfigurationWrapper RunnerId="Debug" />
+    <ConfigurationWrapper RunnerId="Run" />
+    <method />
+  </configuration>
+</component>

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapSubDiseaseDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/HealthMapSubDiseaseDaoTest.java
@@ -21,7 +21,7 @@ public class HealthMapSubDiseaseDaoTest extends AbstractCommonSpringIntegrationT
     @Test
     public void getAllHealthMapSubDiseases() {
         List<HealthMapSubDisease> subDiseases = healthMapSubDiseaseDao.getAll();
-        assertThat(subDiseases).hasSize(22);
+        assertThat(subDiseases).hasSize(35);
     }
 
     @Test

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirer.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirer.java
@@ -27,9 +27,9 @@ public class DiseaseOccurrenceDataAcquirer {
             "More than one location already exists at point (%f,%f) and with precision %s. Arbitrarily using " +
             "location ID %d.";
     private static final String OCCURRENCE_IS_TOO_OLD =
-            "Occurrence date for occurrence is older than the max allowable age.";
+            "Occurrence date for occurrence is older than the max allowable age";
     private static final String OCCURRENCE_IS_IN_THE_FUTURE =
-            "Occurrence date for occurrence is in the future.";
+            "Occurrence date for occurrence is in the future";
 
     private DiseaseService diseaseService;
     private LocationService locationService;

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirer.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirer.java
@@ -75,7 +75,7 @@ public class DiseaseOccurrenceDataAcquirer {
     }
 
     private void rejectOccurrenceIfOccurrenceDateInvalid(DiseaseOccurrence occurrence) {
-        if (!occurrenceIsGoldStandard(occurrence) && occurrenceIsTooOld(occurrence)) {
+        if (!occurrenceIsCSV(occurrence) && occurrenceIsTooOld(occurrence)) {
             throw new DataAcquisitionException(OCCURRENCE_IS_TOO_OLD);
         } else if (occurrenceIsInTheFuture(occurrence)) {
             throw new DataAcquisitionException(OCCURRENCE_IS_IN_THE_FUTURE);
@@ -93,8 +93,9 @@ public class DiseaseOccurrenceDataAcquirer {
                 .isAfter(DateTime.now().withTimeAtStartOfDay());
     }
 
-    private boolean occurrenceIsGoldStandard(DiseaseOccurrence occurrence) {
-        return occurrence.getAlert().getFeed().getProvenance().getName().equals(ProvenanceNames.MANUAL_GOLD_STANDARD);
+    private boolean occurrenceIsCSV(DiseaseOccurrence occurrence) {
+        final String provenceName = occurrence.getAlert().getFeed().getProvenance().getName();
+        return provenceName.equals(ProvenanceNames.MANUAL_GOLD_STANDARD) || provenceName.equals(ProvenanceNames.MANUAL);
     }
 
     // Returns the converted location, or null if the location could not be converted further

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataAcquirer.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataAcquirer.java
@@ -6,6 +6,7 @@ import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.Provenance;
 import org.apache.commons.io.FileUtils;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.web.JsonParserException;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.web.WebServiceClientException;
+import uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.DataAcquisitionException;
 import uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.healthmap.domain.HealthMapLocation;
 
 import java.io.File;
@@ -62,7 +63,7 @@ public class HealthMapDataAcquirer {
             return healthMapWebService.sendRequest(startDate, endDate);
         } catch (WebServiceClientException|JsonParserException e) {
             LOGGER.fatal(String.format(WEB_SERVICE_ERROR_MESSAGE, e.getMessage()), e);
-            return null;
+            throw new DataAcquisitionException(e.getMessage(), e);
         }
     }
 
@@ -72,14 +73,14 @@ public class HealthMapDataAcquirer {
             json = FileUtils.readFileToString(new File(jsonFileName), StandardCharsets.UTF_8);
         } catch (IOException e) {
             LOGGER.fatal(String.format(FILE_ERROR_MESSAGE, e.getMessage()), e);
-            return null;
+            throw new DataAcquisitionException(e.getMessage(), e);
         }
 
         try {
             return healthMapWebService.parseJson(json);
         } catch (JsonParserException e) {
             LOGGER.fatal(String.format(JSON_ERROR_MESSAGE, e.getMessage()), e);
-            return null;
+            throw new DataAcquisitionException(e.getMessage(), e);
         }
     }
 

--- a/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataConverter.java
+++ b/src/DataAcquisition/src/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataConverter.java
@@ -79,13 +79,13 @@ public class HealthMapDataConverter {
         if (healthMapLocation.getAlerts() != null) {
             for (HealthMapAlert healthMapAlert : healthMapLocation.getAlerts()) {
                 for (DiseaseOccurrence occurrence : alertConverter.convert(healthMapAlert, location)) {
-                    if (diseaseOccurrenceDataAcquirer.acquire(occurrence)) {
-                        try {
+                    try {
+                        if (diseaseOccurrenceDataAcquirer.acquire(occurrence)) {
                             convertedOccurrences.add(occurrence);
-                        } catch (DataAcquisitionException e) {
-                            // DataAcquisitionException should not cause a roll back (occurrence age check failed)
-                            LOGGER.warn(e.getMessage());
                         }
+                    } catch (DataAcquisitionException e) {
+                        // DataAcquisitionException should not cause a roll back (occurrence age check failed)
+                        LOGGER.warn(e.getMessage());
                     }
                 }
             }

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirerTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirerTest.java
@@ -291,7 +291,7 @@ public class DiseaseOccurrenceDataAcquirerTest {
         catchException(acquirer).acquire(occurrence);
 
         // Assert
-        assertThat(caughtException()).hasMessage("Occurrence date for occurrence is older than the max allowable age.");
+        assertThat(caughtException()).hasMessage("Occurrence date for occurrence is older than the max allowable age");
         verify(diseaseService, never()).saveDiseaseOccurrence(any(DiseaseOccurrence.class));
     }
 
@@ -323,7 +323,7 @@ public class DiseaseOccurrenceDataAcquirerTest {
         catchException(acquirer).acquire(occurrence);
 
         // Assert
-        assertThat(caughtException()).hasMessage("Occurrence date for occurrence is in the future.");
+        assertThat(caughtException()).hasMessage("Occurrence date for occurrence is in the future");
         verify(diseaseService, never()).saveDiseaseOccurrence(any(DiseaseOccurrence.class));
     }
 

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirerTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/DiseaseOccurrenceDataAcquirerTest.java
@@ -296,7 +296,25 @@ public class DiseaseOccurrenceDataAcquirerTest {
     }
 
     @Test
-    public void acquireSavesOutdatedGoldStandardDiseaseOccurrence() {
+    public void acquireSavesOutdatedGoldStandardCSVDiseaseOccurrence() {
+        // Arrange
+        DiseaseOccurrence occurrence = createGoldStandardOccurrence();
+        occurrence.setOccurrenceDate(DateTime.now().minusYears(1).minusDays(1));
+        mockGetLocationsByPointAndPrecision(occurrence.getLocation().getGeom(), occurrence.getLocation().getPrecision(),
+                new ArrayList<Location>());
+        mockRunQC(occurrence.getLocation(), true);
+
+        // Act
+        boolean result = acquirer.acquire(occurrence);
+
+        // Assert
+        assertThat(occurrence.getLocation().hasPassedQc()).isTrue();
+        verify(postQcManager).runPostQCProcesses(same(occurrence.getLocation()));
+        verifySuccessfulSave(occurrence, true, result);
+    }
+
+    @Test
+    public void acquireSavesOutdatedNoGoldStandardCSVDiseaseOccurrence() {
         // Arrange
         DiseaseOccurrence occurrence = createGoldStandardOccurrence();
         occurrence.setOccurrenceDate(DateTime.now().minusYears(1).minusDays(1));
@@ -350,7 +368,7 @@ public class DiseaseOccurrenceDataAcquirerTest {
         Location location = new Location(20, 10, LocationPrecision.ADMIN1);
         occurrence.setLocation(location);
         occurrence.setOccurrenceDate(DateTime.now());
-        setAlert(occurrence, false);
+        setAlert(occurrence, ProvenanceNames.HEALTHMAP);
         return occurrence;
     }
 
@@ -359,12 +377,20 @@ public class DiseaseOccurrenceDataAcquirerTest {
         Location location = new Location(20, 10, LocationPrecision.ADMIN1);
         occurrence.setLocation(location);
         occurrence.setOccurrenceDate(DateTime.now());
-        setAlert(occurrence, true);
+        setAlert(occurrence, ProvenanceNames.MANUAL_GOLD_STANDARD);
         return occurrence;
     }
 
-    private void setAlert(DiseaseOccurrence occurrence, boolean isGoldStandard) {
-        String provenanceName = isGoldStandard ? ProvenanceNames.MANUAL_GOLD_STANDARD : ProvenanceNames.MANUAL;
+    private DiseaseOccurrence createManualCSVOccurrence() {
+        DiseaseOccurrence occurrence = new DiseaseOccurrence();
+        Location location = new Location(20, 10, LocationPrecision.ADMIN1);
+        occurrence.setLocation(location);
+        occurrence.setOccurrenceDate(DateTime.now());
+        setAlert(occurrence, ProvenanceNames.MANUAL);
+        return occurrence;
+    }
+
+    private void setAlert(DiseaseOccurrence occurrence, String provenanceName) {
         Feed feed = new Feed("Manual data", new Provenance(provenanceName));
         Alert alert = new Alert();
         alert.setFeed(feed);

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataAcquirerIntegrationTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataAcquirerIntegrationTest.java
@@ -2,12 +2,18 @@ package uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.healthmap;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.web.JsonParserException;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.web.WebServiceClient;
+import uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.DataAcquisitionException;
 import uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.healthmap.domain.HealthMapLocation;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -42,10 +48,12 @@ public class HealthMapDataAcquirerIntegrationTest {
 
         // Act
         HealthMapDataAcquirer dataAcquisition = new HealthMapDataAcquirer(webService, dataConverter, lookupData);
-        dataAcquisition.acquireDataFromFile(fileName);
+        catchException(dataAcquisition).acquireDataFromFile(fileName);
 
         // Assert
         verify(dataConverter, never()).convert(eq(locations), eq((DateTime) null));
+        assertThat(caughtException()).isInstanceOf(DataAcquisitionException.class);
+        assertThat(caughtException().getCause()).isInstanceOf(JsonParserException.class);
     }
 
     @Test
@@ -56,9 +64,11 @@ public class HealthMapDataAcquirerIntegrationTest {
 
         // Act
         HealthMapDataAcquirer dataAcquisition = new HealthMapDataAcquirer(webService, dataConverter, lookupData);
-        dataAcquisition.acquireDataFromFile(fileName);
+        catchException(dataAcquisition).acquireDataFromFile(fileName);
 
         // Assert
         verify(dataConverter, never()).convert(eq(locations), eq((DateTime) null));
+        assertThat(caughtException()).isInstanceOf(DataAcquisitionException.class);
+        assertThat(caughtException().getCause()).isInstanceOf(IOException.class);
     }
 }

--- a/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataAcquirerTest.java
+++ b/src/DataAcquisition/test/uk/ac/ox/zoo/seeg/abraid/mp/dataacquisition/acquirers/healthmap/HealthMapDataAcquirerTest.java
@@ -5,11 +5,15 @@ import org.joda.time.DateTimeUtils;
 import org.junit.Test;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.Provenance;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.web.WebServiceClientException;
+import uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.DataAcquisitionException;
 import uk.ac.ox.zoo.seeg.abraid.mp.dataacquisition.acquirers.healthmap.domain.HealthMapLocation;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -186,11 +190,13 @@ public class HealthMapDataAcquirerTest {
 
         // Act
         HealthMapDataAcquirer dataAcquisition = new HealthMapDataAcquirer(webService, dataConverter, lookupData);
-        dataAcquisition.acquireDataFromWebService();
+        catchException(dataAcquisition).acquireDataFromWebService();
 
         // Assert
         //noinspection unchecked
         verify(dataConverter, never()).convert(anyList(), any(DateTime.class));
+        assertThat(caughtException()).isInstanceOf(DataAcquisitionException.class);
+        assertThat(caughtException().getCause()).isInstanceOf(WebServiceClientException.class);
     }
 
     private void fixCurrentDateTime() {

--- a/src/DataManager/src/uk/ac/ox/zoo/seeg/abraid/mp/datamanager/Main.java
+++ b/src/DataManager/src/uk/ac/ox/zoo/seeg/abraid/mp/datamanager/Main.java
@@ -1,6 +1,7 @@
 package uk.ac.ox.zoo.seeg.abraid.mp.datamanager;
 
 import org.apache.log4j.Logger;
+import org.joda.time.LocalDate;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.DiseaseService;
@@ -25,6 +26,8 @@ public class Main {
     private static final Logger LOGGER = Logger.getLogger(Main.class);
     private static final String STARTED_MESSAGE = "Data Manager version %s: started";
     private static final String FINISHED_MESSAGE = "Data Manager finished";
+    private static final String ERROR_MESSAGE =
+            "The '%s' step of the daily ABRAID process for '%s' failed: '%s'";
 
     private final DiseaseService diseaseService;
     private final DataAcquisitionManager dataAcquisitionManager;
@@ -100,6 +103,13 @@ public class Main {
         System.out.println(message);
     }
 
+    private void logError(String step, Exception e) {
+        String message = String.format(
+                ERROR_MESSAGE, step, LocalDate.now().toString("YYYY-MM-dd"), e.getMessage());
+        LOGGER.fatal(message);
+        System.out.println(message);
+    }
+
     private List<Integer> getDiseaseGroupIdsForAutomaticModelRuns() {
         List<Integer> diseaseGroupIdsForAutomaticModelRuns = diseaseService.getDiseaseGroupIdsForAutomaticModelRuns();
         // Return a mutable version of the list.
@@ -113,10 +123,10 @@ public class Main {
         try {
             diseaseProcessManager.updateExpertsWeightings();
         } catch (Exception e) { ///CHECKSTYLE:SUPPRESS EmptyBlock
-            // Ignore the exception, because it is thrown to roll back the transaction if the process step fails.
-            // Logging has already been done by this point.
+            // Exception is thrown to roll back the transaction if the process step fails.
+            // Logging has probably already been done by this point, but best to log it again for safety.
+            logError("update experts' scores", e);
         }
-
     }
 
     /**
@@ -128,8 +138,9 @@ public class Main {
             try {
                 diseaseProcessManager.processOccurrencesOnDataValidator(diseaseGroupId);
             } catch (Exception e) { ///CHECKSTYLE:SUPPRESS EmptyBlock
-                // Ignore the exception, because it is thrown to roll back the transaction per disease group if the
-                // process step fails. Logging has already been done by this point.
+                // Exception is thrown to roll back the transaction if the process step fails.
+                // Logging has probably already been done by this point, but best to log it again for safety.
+                logError("process occurrence on the validator", e);
             }
         }
     }
@@ -143,8 +154,9 @@ public class Main {
         try {
             dataAcquisitionManager.runDataAcquisition(fileNames);
         } catch (Exception e) { ///CHECKSTYLE:SUPPRESS EmptyBlock
-            // Ignore the exception, because it is thrown to roll back the transaction per disease group if the
-            // process step fails. Logging has already been done by this point.
+            // Exception is thrown to roll back the transaction if the process step fails.
+            // Logging has probably already been done by this point, but best to log it again for safety.
+            logError("acquire new data", e);
         }
     }
 
@@ -158,8 +170,9 @@ public class Main {
             try {
                 diseaseProcessManager.updateDiseaseExtents(diseaseGroupId);
             } catch (Exception e) { ///CHECKSTYLE:SUPPRESS EmptyBlock
-                // Catch the exception, because it is thrown to roll back the transaction per disease group if the
-                // process step fails. Logging has already been done by this point.
+                // Exception is thrown to roll back the transaction if the process step fails.
+                // Logging has probably already been done by this point, but best to log it again for safety.
+                logError(String.format("update disease extent for ID=%s (if required)", diseaseGroupId), e);
 
                 // If extent generation fails for a disease, we should not attempt a model run today for that disease
                 diseaseGroupIdsForAutomaticModelRuns.remove(diseaseGroupId);
@@ -176,8 +189,9 @@ public class Main {
             try {
                 diseaseProcessManager.requestModelRun(diseaseGroupId);
             } catch (Exception e) { ///CHECKSTYLE:SUPPRESS EmptyBlock
-                // Ignore the exception, because it is thrown to roll back the transaction per disease group if the
-                // process step fails. Logging has already been done by this point.
+                // Exception is thrown to roll back the transaction if the process step fails.
+                // Logging has probably already been done by this point, but best to log it again for safety.
+                logError(String.format("request model run for ID=%s (if required)", diseaseGroupId), e);
             }
         }
     }


### PR DESCRIPTION
* Fix critical bug preventing nightly acquisition of HM data when old data is present (see c48bab3).
* Ensure better logging for similar situations
* Add new HM sub-diseases from logs
* Stop applying old data filter to CSV

