### PR TITLE
Distance to extent performance v2

### DIFF
--- a/db/migrations/1508061144__add_distance_to_extent_cache.sql
+++ b/db/migrations/1508061144__add_distance_to_extent_cache.sql
@@ -1,0 +1,13 @@
+-- Add a table to cached distance to disease extent values
+--
+-- Copyright (c) 2015 University of Oxford
+CREATE TABLE disease_to_extent_cache (
+    disease_group_id integer NOT NULL 
+        CONSTRAINT fk_disease_to_extent_cache_disease_group REFERENCES disease_group (id),
+    location_id integer NOT NULL
+        CONSTRAINT fk_disease_to_extent_cache_location REFERENCES location (id),
+    distance double precision NOT NULL,
+    CONSTRAINT pk_disease_to_extent_cache PRIMARY KEY (disease_group_id, location_id)
+);
+
+GRANT SELECT, INSERT, DELETE ON disease_to_extent_cache TO ${application_username};

--- a/db/migrations/1508061150__add_environmental_suitability_cache.sql
+++ b/db/migrations/1508061150__add_environmental_suitability_cache.sql
@@ -1,0 +1,13 @@
+-- Add a table to cache environmental suitability values
+--
+-- Copyright (c) 2015 University of Oxford
+CREATE TABLE environmental_suitability_cache (
+    disease_group_id integer NOT NULL 
+        CONSTRAINT fk_environmental_suitability_cache_disease_group REFERENCES disease_group (id),
+    location_id integer NOT NULL
+        CONSTRAINT fk_environmental_suitability_cache_location REFERENCES location (id),
+    environmental_suitability double precision NOT NULL,
+    CONSTRAINT pk_environmental_suitability_cache PRIMARY KEY (disease_group_id, location_id)
+);
+
+GRANT SELECT, INSERT, DELETE ON environmental_suitability_cache TO ${application_username};

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-database.xml
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-database.xml
@@ -21,6 +21,7 @@
     <bean id="covariateFileDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.CovariateFileDaoImpl" autowire="constructor" />
     <bean id="covariateInfluenceDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.CovariateInfluenceDaoImpl" autowire="constructor" />
     <bean id="diseaseExtentClassDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseExtentClassDaoImpl" autowire="constructor" />
+    <bean id="distanceToExtentCacheEntryDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DistanceToExtentCacheEntryDaoImpl" autowire="constructor" />
     <bean id="diseaseGroupDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseGroupDaoImpl" autowire="constructor" />
     <bean id="diseaseOccurrenceDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseOccurrenceDaoImpl" autowire="constructor" />
     <bean id="diseaseOccurrenceReviewDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseOccurrenceReviewDaoImpl" autowire="constructor" />

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-database.xml
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-database.xml
@@ -21,11 +21,12 @@
     <bean id="covariateFileDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.CovariateFileDaoImpl" autowire="constructor" />
     <bean id="covariateInfluenceDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.CovariateInfluenceDaoImpl" autowire="constructor" />
     <bean id="diseaseExtentClassDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseExtentClassDaoImpl" autowire="constructor" />
-    <bean id="distanceToExtentCacheEntryDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DistanceToExtentCacheEntryDaoImpl" autowire="constructor" />
     <bean id="diseaseGroupDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseGroupDaoImpl" autowire="constructor" />
     <bean id="diseaseOccurrenceDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseOccurrenceDaoImpl" autowire="constructor" />
     <bean id="diseaseOccurrenceReviewDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DiseaseOccurrenceReviewDaoImpl" autowire="constructor" />
+    <bean id="distanceToExtentCacheEntryDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DistanceToExtentCacheEntryDaoImpl" autowire="constructor" />
     <bean id="effectCurveCovariateInfluenceDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.EffectCurveCovariateInfluenceDaoImpl" autowire="constructor" />
+    <bean id="environmentalSuitabilityCacheEntryDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.EnvironmentalSuitabilityCacheEntryDaoImpl" autowire="constructor" />
     <bean id="expertDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.ExpertDaoImpl" autowire="constructor" />
     <bean id="feedDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.FeedDaoImpl" autowire="constructor" />
     <bean id="geoNameDao" class="uk.ac.ox.zoo.seeg.abraid.mp.common.dao.GeoNameDaoImpl" autowire="constructor" />

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-service.xml
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-service.xml
@@ -26,6 +26,7 @@
     <bean id="locationService" class="uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationServiceImpl" autowire="constructor"/>
     <bean id="geometryService" class="uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.GeometryServiceImpl" autowire="constructor"/>
     <bean id="modelRunService" class="uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ModelRunServiceImpl" autowire="constructor"/>
+    <bean id="validationParameterCacheService" class="uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ValidationParameterCacheServiceImpl" autowire="constructor"/>
     <import resource="classpath:uk/ac/ox/zoo/seeg/abraid/mp/common/config/beans-email-service.xml"/>
 
     <!-- Business workflow services -->

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDao.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDao.java
@@ -1,7 +1,7 @@
 package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
 
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
 
 /**
  * Interface for the DistanceToExtentCacheEntry entity's Data Access Object.
@@ -13,7 +13,7 @@ public interface DistanceToExtentCacheEntryDao {
      * @param id The location and disease pair.
      * @return The cached entry or null.
      */
-    DistanceToExtentCacheEntry getById(DistanceToExtentCacheEntryId id);
+    DistanceToExtentCacheEntry getById(ValidationParameterCacheEntryId id);
 
     /**
      * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDao.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDao.java
@@ -1,0 +1,29 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
+
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
+
+/**
+ * Interface for the DistanceToExtentCacheEntry entity's Data Access Object.
+ * Copyright (c) 2015 University of Oxford
+ */
+public interface DistanceToExtentCacheEntryDao {
+    /**
+     * Gets the cached "distance to disease extent" entry for a location and disease pair, or null if not in the cache.
+     * @param id The location and disease pair.
+     * @return The cached entry or null.
+     */
+    DistanceToExtentCacheEntry getById(DistanceToExtentCacheEntryId id);
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    void clearCacheForDisease(int diseaseGroupId);
+
+    /**
+     * Add a "distance to disease extent" entry to the cache.
+     * @param distanceToExtentCacheEntry The entry to save.
+     */
+    void save(DistanceToExtentCacheEntry distanceToExtentCacheEntry);
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoImpl.java
@@ -2,14 +2,14 @@ package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
 
 import org.hibernate.SessionFactory;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
 
 /**
  * The DistanceToExtentCacheEntry entity's Data Access Object.
  * Copyright (c) 2015 University of Oxford
  */
 public class DistanceToExtentCacheEntryDaoImpl
-        extends AbstractDao<DistanceToExtentCacheEntry, DistanceToExtentCacheEntryId>
+        extends AbstractDao<DistanceToExtentCacheEntry, ValidationParameterCacheEntryId>
         implements DistanceToExtentCacheEntryDao {
 
     public DistanceToExtentCacheEntryDaoImpl(SessionFactory sessionFactory) {
@@ -22,6 +22,6 @@ public class DistanceToExtentCacheEntryDaoImpl
      */
     @Override
     public void clearCacheForDisease(int diseaseGroupId) {
-        noResultNamedQuery("clearCacheForDisease", "diseaseGroupId", diseaseGroupId);
+        noResultNamedQuery("clearDistanceToExtentCacheForDisease", "diseaseGroupId", diseaseGroupId);
     }
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoImpl.java
@@ -1,0 +1,27 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
+
+import org.hibernate.SessionFactory;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
+
+/**
+ * The DistanceToExtentCacheEntry entity's Data Access Object.
+ * Copyright (c) 2015 University of Oxford
+ */
+public class DistanceToExtentCacheEntryDaoImpl
+        extends AbstractDao<DistanceToExtentCacheEntry, DistanceToExtentCacheEntryId>
+        implements DistanceToExtentCacheEntryDao {
+
+    public DistanceToExtentCacheEntryDaoImpl(SessionFactory sessionFactory) {
+        super(sessionFactory);
+    }
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    @Override
+    public void clearCacheForDisease(int diseaseGroupId) {
+        noResultNamedQuery("clearCacheForDisease", "diseaseGroupId", diseaseGroupId);
+    }
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/EnvironmentalSuitabilityCacheEntryDao.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/EnvironmentalSuitabilityCacheEntryDao.java
@@ -1,0 +1,29 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
+
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.EnvironmentalSuitabilityCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
+
+/**
+ * Interface for the EnvironmentalSuitabilityCacheEntry entity's Data Access Object.
+ * Copyright (c) 2015 University of Oxford
+ */
+public interface EnvironmentalSuitabilityCacheEntryDao {
+    /**
+     * Gets the cached "environmental suitability" entry for a location and disease pair, or null if not in the cache.
+     * @param id The location and disease pair.
+     * @return The cached entry or null.
+     */
+    EnvironmentalSuitabilityCacheEntry getById(ValidationParameterCacheEntryId id);
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the raster has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    void clearCacheForDisease(int diseaseGroupId);
+
+    /**
+     * Add a "distance to disease extent" entry to the cache.
+     * @param environmentalSuitabilityCacheEntry The entry to save.
+     */
+    void save(EnvironmentalSuitabilityCacheEntry environmentalSuitabilityCacheEntry);
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/EnvironmentalSuitabilityCacheEntryDaoImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/EnvironmentalSuitabilityCacheEntryDaoImpl.java
@@ -1,0 +1,27 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
+
+import org.hibernate.SessionFactory;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.EnvironmentalSuitabilityCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
+
+/**
+ * The EnvironmentalSuitabilityCacheEntry entity's Data Access Object.
+ * Copyright (c) 2015 University of Oxford
+ */
+public class EnvironmentalSuitabilityCacheEntryDaoImpl
+        extends AbstractDao<EnvironmentalSuitabilityCacheEntry, ValidationParameterCacheEntryId>
+        implements EnvironmentalSuitabilityCacheEntryDao {
+
+    public EnvironmentalSuitabilityCacheEntryDaoImpl(SessionFactory sessionFactory) {
+        super(sessionFactory);
+    }
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the raster has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    @Override
+    public void clearCacheForDisease(int diseaseGroupId) {
+        noResultNamedQuery("clearEnvironmentalSuitabilityCacheForDisease", "diseaseGroupId", diseaseGroupId);
+    }
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DistanceToExtentCacheEntry.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DistanceToExtentCacheEntry.java
@@ -8,29 +8,23 @@ import javax.persistence.*;
  */
 @NamedQueries({
         @NamedQuery(
-                name = "clearCacheForDisease",
+                name = "clearDistanceToExtentCacheForDisease",
                 query = "delete from DistanceToExtentCacheEntry where id.diseaseGroupId=:diseaseGroupId"
         )
 })
 @Entity
 @Table(name = "disease_to_extent_cache")
-public class DistanceToExtentCacheEntry {
-    @EmbeddedId
-    private DistanceToExtentCacheEntryId id;
-
+public class DistanceToExtentCacheEntry extends ValidationParameterCacheEntry {
     @Column(name = "distance", nullable = false)
     private double distance;
 
     public DistanceToExtentCacheEntry() {
+        super();
     }
 
     public DistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance) {
-        this.id = new DistanceToExtentCacheEntryId(diseaseGroupId, locationId);
-        this.distance = distance;
-    }
-
-    public DistanceToExtentCacheEntryId getId() {
-        return id;
+        super(diseaseGroupId, locationId);
+        setDistance(distance);
     }
 
     public double getDistance() {
@@ -47,20 +41,19 @@ public class DistanceToExtentCacheEntry {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
 
-        DistanceToExtentCacheEntry that = (DistanceToExtentCacheEntry) o;
+        DistanceToExtentCacheEntry entry = (DistanceToExtentCacheEntry) o;
 
-        if (Double.compare(that.distance, distance) != 0) return false;
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (Double.compare(entry.distance, distance) != 0) return false;
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        int result;
+        int result = super.hashCode();
         long temp;
-        result = id != null ? id.hashCode() : 0;
         temp = Double.doubleToLongBits(distance);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         return result;

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DistanceToExtentCacheEntry.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DistanceToExtentCacheEntry.java
@@ -1,0 +1,70 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.domain;
+
+import javax.persistence.*;
+
+/**
+ * Represents an entry in the set of cached "distance to disease extent" values.
+ * Copyright (c) 2015 University of Oxford
+ */
+@NamedQueries({
+        @NamedQuery(
+                name = "clearCacheForDisease",
+                query = "delete from DistanceToExtentCacheEntry where id.diseaseGroupId=:diseaseGroupId"
+        )
+})
+@Entity
+@Table(name = "disease_to_extent_cache")
+public class DistanceToExtentCacheEntry {
+    @EmbeddedId
+    private DistanceToExtentCacheEntryId id;
+
+    @Column(name = "distance", nullable = false)
+    private double distance;
+
+    public DistanceToExtentCacheEntry() {
+    }
+
+    public DistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance) {
+        this.id = new DistanceToExtentCacheEntryId(diseaseGroupId, locationId);
+        this.distance = distance;
+    }
+
+    public DistanceToExtentCacheEntryId getId() {
+        return id;
+    }
+
+    public double getDistance() {
+        return distance;
+    }
+
+    public void setDistance(double distance) {
+        this.distance = distance;
+    }
+
+    ///COVERAGE:OFF - generated code
+    ///CHECKSTYLE:OFF AvoidInlineConditionalsCheck|LineLengthCheck|MagicNumberCheck|NeedBracesCheck - generated code
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DistanceToExtentCacheEntry that = (DistanceToExtentCacheEntry) o;
+
+        if (Double.compare(that.distance, distance) != 0) return false;
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        long temp;
+        result = id != null ? id.hashCode() : 0;
+        temp = Double.doubleToLongBits(distance);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+    ///CHECKSTYLE:ON
+    ///COVERAGE:ON
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DistanceToExtentCacheEntryId.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DistanceToExtentCacheEntryId.java
@@ -1,0 +1,66 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+/**
+ * A composite primary key used on DistanceToExtentCacheEntry objects.
+ * Copyright (c) 2015 University of Oxford
+ */
+@Embeddable
+public class DistanceToExtentCacheEntryId implements Serializable {
+    @Column(name = "disease_group_id", nullable = false)
+    private int diseaseGroupId;
+
+    @Column(name = "location_id", nullable = false)
+    private int locationId;
+
+    public DistanceToExtentCacheEntryId() {
+    }
+
+    public DistanceToExtentCacheEntryId(int diseaseGroupId, int locationId) {
+        setDiseaseGroupId(diseaseGroupId);
+        setLocationId(locationId);
+    }
+
+    public int getDiseaseGroupId() {
+        return diseaseGroupId;
+    }
+
+    public void setDiseaseGroupId(int diseaseGroupId) {
+        this.diseaseGroupId = diseaseGroupId;
+    }
+
+    public int getLocationId() {
+        return locationId;
+    }
+
+    public void setLocationId(int locationId) {
+        this.locationId = locationId;
+    }
+
+    ///COVERAGE:OFF - generated code
+    ///CHECKSTYLE:OFF AvoidInlineConditionalsCheck|LineLengthCheck|MagicNumberCheck|NeedBracesCheck - generated code
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DistanceToExtentCacheEntryId that = (DistanceToExtentCacheEntryId) o;
+
+        if (diseaseGroupId != that.diseaseGroupId) return false;
+        if (locationId != that.locationId) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = diseaseGroupId;
+        result = 31 * result + locationId;
+        return result;
+    }
+    ///CHECKSTYLE:ON
+    ///COVERAGE:ON
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/EnvironmentalSuitabilityCacheEntry.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/EnvironmentalSuitabilityCacheEntry.java
@@ -1,0 +1,63 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.domain;
+
+import javax.persistence.*;
+
+/**
+ * Represents an entry in the set of cached "environmental suitability" values.
+ * Copyright (c) 2015 University of Oxford
+ */
+@NamedQueries({
+        @NamedQuery(
+                name = "clearEnvironmentalSuitabilityCacheForDisease",
+                query = "delete from EnvironmentalSuitabilityCacheEntry where id.diseaseGroupId=:diseaseGroupId"
+        )
+})
+@Entity
+@Table(name = "environmental_suitability_cache")
+public class EnvironmentalSuitabilityCacheEntry extends ValidationParameterCacheEntry {
+    @Column(name = "environmental_suitability", nullable = false)
+    private double environmentalSuitability;
+
+    public EnvironmentalSuitabilityCacheEntry() {
+        super();
+    }
+
+    public EnvironmentalSuitabilityCacheEntry(int diseaseGroupId, int locationId, double environmentalSuitability) {
+        super(diseaseGroupId, locationId);
+        setEnvironmentalSuitability(environmentalSuitability);
+    }
+
+    public double getEnvironmentalSuitability() {
+        return environmentalSuitability;
+    }
+
+    public void setEnvironmentalSuitability(double environmentalSuitability) {
+        this.environmentalSuitability = environmentalSuitability;
+    }
+
+    ///COVERAGE:OFF - generated code
+    ///CHECKSTYLE:OFF AvoidInlineConditionalsCheck|LineLengthCheck|MagicNumberCheck|NeedBracesCheck - generated code
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        EnvironmentalSuitabilityCacheEntry entry = (EnvironmentalSuitabilityCacheEntry) o;
+
+        if (Double.compare(entry.environmentalSuitability, environmentalSuitability) != 0) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        long temp;
+        temp = Double.doubleToLongBits(environmentalSuitability);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+    ///CHECKSTYLE:ON
+    ///COVERAGE:ON
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/ValidationParameterCacheEntry.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/ValidationParameterCacheEntry.java
@@ -1,0 +1,50 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.domain;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.MappedSuperclass;
+
+/**
+ * Base class for cached validation parameter values.
+ * Copyright (c) 2015 University of Oxford
+ */
+@MappedSuperclass
+public class ValidationParameterCacheEntry {
+    @EmbeddedId
+    private ValidationParameterCacheEntryId id;
+
+    public ValidationParameterCacheEntry() {
+    }
+
+    public ValidationParameterCacheEntry(int diseaseGroupId, int locationId) {
+        this.id = new ValidationParameterCacheEntryId(diseaseGroupId, locationId);
+    }
+
+    public ValidationParameterCacheEntryId getId() {
+        return id;
+    }
+
+    public void setId(ValidationParameterCacheEntryId id) {
+        this.id = id;
+    }
+
+    ///COVERAGE:OFF - generated code
+    ///CHECKSTYLE:OFF AvoidInlineConditionalsCheck|LineLengthCheck|MagicNumberCheck|NeedBracesCheck - generated code
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ValidationParameterCacheEntry that = (ValidationParameterCacheEntry) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+    ///CHECKSTYLE:ON
+    ///COVERAGE:ON
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/ValidationParameterCacheEntryId.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/ValidationParameterCacheEntryId.java
@@ -5,21 +5,21 @@ import javax.persistence.Embeddable;
 import java.io.Serializable;
 
 /**
- * A composite primary key used on DistanceToExtentCacheEntry objects.
+ * A composite primary key used on ValidationParameterCacheEntryId objects.
  * Copyright (c) 2015 University of Oxford
  */
 @Embeddable
-public class DistanceToExtentCacheEntryId implements Serializable {
+public class ValidationParameterCacheEntryId implements Serializable {
     @Column(name = "disease_group_id", nullable = false)
     private int diseaseGroupId;
 
     @Column(name = "location_id", nullable = false)
     private int locationId;
 
-    public DistanceToExtentCacheEntryId() {
+    public ValidationParameterCacheEntryId() {
     }
 
-    public DistanceToExtentCacheEntryId(int diseaseGroupId, int locationId) {
+    public ValidationParameterCacheEntryId(int diseaseGroupId, int locationId) {
         setDiseaseGroupId(diseaseGroupId);
         setLocationId(locationId);
     }
@@ -47,7 +47,7 @@ public class DistanceToExtentCacheEntryId implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        DistanceToExtentCacheEntryId that = (DistanceToExtentCacheEntryId) o;
+        ValidationParameterCacheEntryId that = (ValidationParameterCacheEntryId) o;
 
         if (diseaseGroupId != that.diseaseGroupId) return false;
         if (locationId != that.locationId) return false;

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationService.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationService.java
@@ -56,26 +56,4 @@ public interface LocationService {
      * @param location The location to save.
      */
     void saveLocation(Location location);
-
-     /**
-     * Gets the cached "distance to disease extent" value for a location and disease pair, or null if not in the cache.
-     * @param diseaseGroupId The id of the disease group.
-     * @param locationId The id of the location.
-     * @return The cached value or null.
-     */
-    Double getDistanceToExtentFromCache(int diseaseGroupId, int locationId);
-
-    /**
-     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
-     * @param diseaseGroupId The id of the disease group.
-     */
-    void clearDistanceToExtentCacheForDisease(int diseaseGroupId);
-
-    /**
-     * Add a "distance to disease extent" value to the cache.
-     * @param diseaseGroupId The id of the disease group.
-     * @param locationId The id of the location.
-     * @param distance The distance to cache.
-     */
-    void saveDistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance);
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationService.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationService.java
@@ -56,4 +56,26 @@ public interface LocationService {
      * @param location The location to save.
      */
     void saveLocation(Location location);
+
+     /**
+     * Gets the cached "distance to disease extent" value for a location and disease pair, or null if not in the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @return The cached value or null.
+     */
+    Double getDistanceToExtentFromCache(int diseaseGroupId, int locationId);
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    void clearDistanceToExtentCacheForDisease(int diseaseGroupId);
+
+    /**
+     * Add a "distance to disease extent" value to the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @param distance The distance to cache.
+     */
+    void saveDistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance);
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationServiceImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationServiceImpl.java
@@ -2,13 +2,13 @@ package uk.ac.ox.zoo.seeg.abraid.mp.common.service.core;
 
 import com.vividsolutions.jts.geom.Point;
 import org.springframework.transaction.annotation.Transactional;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.AdminUnitDiseaseExtentClassDao;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.GeoNameDao;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.GeoNamesLocationPrecisionDao;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.LocationDao;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.*;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Service class for locations and associated geoname objects.
@@ -22,14 +22,17 @@ public class LocationServiceImpl implements LocationService {
     private GeoNamesLocationPrecisionDao geoNamesLocationPrecisionDao;
     private GeoNameDao geoNameDao;
     private AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao;
+    private DistanceToExtentCacheEntryDao distanceToExtentCacheDao;
 
 
     public LocationServiceImpl(LocationDao locationDao, GeoNamesLocationPrecisionDao geoNamesLocationPrecisionDao,
-                               GeoNameDao geoNameDao, AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao) {
+                               GeoNameDao geoNameDao, AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao,
+                               DistanceToExtentCacheEntryDao distanceToExtentCacheDao) {
         this.locationDao = locationDao;
         this.geoNamesLocationPrecisionDao = geoNamesLocationPrecisionDao;
         this.geoNameDao = geoNameDao;
         this.adminUnitDiseaseExtentClassDao = adminUnitDiseaseExtentClassDao;
+        this.distanceToExtentCacheDao = distanceToExtentCacheDao;
     }
 
     /**
@@ -116,5 +119,38 @@ public class LocationServiceImpl implements LocationService {
     @Override
     public void saveLocation(Location location) {
         locationDao.save(location);
+    }
+
+    /**
+     * Gets the cached "distance to disease extent" value for a location and disease pair, or null if not in the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId     The id of the location.
+     * @return The cached value or null.
+     */
+    @Override
+    public Double getDistanceToExtentFromCache(int diseaseGroupId, int locationId) {
+        DistanceToExtentCacheEntryId id = new DistanceToExtentCacheEntryId(diseaseGroupId, locationId);
+        DistanceToExtentCacheEntry entry = distanceToExtentCacheDao.getById(id);
+        return (entry != null) ? entry.getDistance() : null;
+    }
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    @Override
+    public void clearDistanceToExtentCacheForDisease(int diseaseGroupId) {
+        distanceToExtentCacheDao.clearCacheForDisease(diseaseGroupId);
+    }
+
+    /**
+     * Add a "distance to disease extent" value to the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @param distance The distance to cache.
+     */
+    @Override
+    public void saveDistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance) {
+        distanceToExtentCacheDao.save(new DistanceToExtentCacheEntry(diseaseGroupId, locationId, distance));
     }
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationServiceImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationServiceImpl.java
@@ -22,17 +22,13 @@ public class LocationServiceImpl implements LocationService {
     private GeoNamesLocationPrecisionDao geoNamesLocationPrecisionDao;
     private GeoNameDao geoNameDao;
     private AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao;
-    private DistanceToExtentCacheEntryDao distanceToExtentCacheDao;
-
 
     public LocationServiceImpl(LocationDao locationDao, GeoNamesLocationPrecisionDao geoNamesLocationPrecisionDao,
-                               GeoNameDao geoNameDao, AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao,
-                               DistanceToExtentCacheEntryDao distanceToExtentCacheDao) {
+                               GeoNameDao geoNameDao, AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao) {
         this.locationDao = locationDao;
         this.geoNamesLocationPrecisionDao = geoNamesLocationPrecisionDao;
         this.geoNameDao = geoNameDao;
         this.adminUnitDiseaseExtentClassDao = adminUnitDiseaseExtentClassDao;
-        this.distanceToExtentCacheDao = distanceToExtentCacheDao;
     }
 
     /**
@@ -119,38 +115,5 @@ public class LocationServiceImpl implements LocationService {
     @Override
     public void saveLocation(Location location) {
         locationDao.save(location);
-    }
-
-    /**
-     * Gets the cached "distance to disease extent" value for a location and disease pair, or null if not in the cache.
-     * @param diseaseGroupId The id of the disease group.
-     * @param locationId     The id of the location.
-     * @return The cached value or null.
-     */
-    @Override
-    public Double getDistanceToExtentFromCache(int diseaseGroupId, int locationId) {
-        DistanceToExtentCacheEntryId id = new DistanceToExtentCacheEntryId(diseaseGroupId, locationId);
-        DistanceToExtentCacheEntry entry = distanceToExtentCacheDao.getById(id);
-        return (entry != null) ? entry.getDistance() : null;
-    }
-
-    /**
-     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
-     * @param diseaseGroupId The id of the disease group.
-     */
-    @Override
-    public void clearDistanceToExtentCacheForDisease(int diseaseGroupId) {
-        distanceToExtentCacheDao.clearCacheForDisease(diseaseGroupId);
-    }
-
-    /**
-     * Add a "distance to disease extent" value to the cache.
-     * @param diseaseGroupId The id of the disease group.
-     * @param locationId The id of the location.
-     * @param distance The distance to cache.
-     */
-    @Override
-    public void saveDistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance) {
-        distanceToExtentCacheDao.save(new DistanceToExtentCacheEntry(diseaseGroupId, locationId, distance));
     }
 }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/ValidationParameterCacheService.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/ValidationParameterCacheService.java
@@ -1,0 +1,51 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.service.core;
+
+/**
+ * Service interface for cached validation parameter values.
+ * Copyright (c) 2015 University of Oxford
+ */
+public interface ValidationParameterCacheService {
+    /**
+     * Gets the cached "distance to disease extent" value for a location and disease pair, or null if not in the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @return The cached value or null.
+     */
+    Double getDistanceToExtentFromCache(int diseaseGroupId, int locationId);
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    void clearDistanceToExtentCacheForDisease(int diseaseGroupId);
+
+    /**
+     * Add a "distance to disease extent" value to the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @param distance The distance to cache.
+     */
+    void saveDistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance);
+
+    /**
+     * Gets the cached "environmental suitability" value for a location and disease pair, or null if not in the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @return The cached value or null.
+     */
+    Double getEnvironmentalSuitabilityFromCache(int diseaseGroupId, int locationId);
+
+    /**
+     * Clears the "environmental suitability" cache of all values for a disease (i.e. the raster has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    void clearEnvironmentalSuitabilityCacheForDisease(int diseaseGroupId);
+
+    /**
+     * Add a "environmental suitability" value to the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @param suitability The suitability to cache.
+     */
+    void saveEnvironmentalSuitabilityCacheEntry(int diseaseGroupId, int locationId, double suitability);
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/ValidationParameterCacheServiceImpl.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/ValidationParameterCacheServiceImpl.java
@@ -1,0 +1,74 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.service.core;
+
+import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DistanceToExtentCacheEntryDao;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.EnvironmentalSuitabilityCacheEntryDao;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.EnvironmentalSuitabilityCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
+
+/**
+ * Service for cached validation parameter values.
+ * Copyright (c) 2015 University of Oxford
+ */
+public class ValidationParameterCacheServiceImpl implements ValidationParameterCacheService {
+    private DistanceToExtentCacheEntryDao distanceToExtentCacheDao;
+    private EnvironmentalSuitabilityCacheEntryDao environmentalSuitabilityCacheDao;
+
+    public ValidationParameterCacheServiceImpl(DistanceToExtentCacheEntryDao distanceToExtentCacheDao,
+                                               EnvironmentalSuitabilityCacheEntryDao environmentalSuitabilityCacheDao) {
+        this.distanceToExtentCacheDao = distanceToExtentCacheDao;
+        this.environmentalSuitabilityCacheDao = environmentalSuitabilityCacheDao;
+    }
+
+    /**
+     * Gets the cached "distance to disease extent" value for a location and disease pair, or null if not in the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId     The id of the location.
+     * @return The cached value or null.
+     */
+    @Override
+    public Double getDistanceToExtentFromCache(int diseaseGroupId, int locationId) {
+        ValidationParameterCacheEntryId id = new ValidationParameterCacheEntryId(diseaseGroupId, locationId);
+        DistanceToExtentCacheEntry entry = distanceToExtentCacheDao.getById(id);
+        return (entry != null) ? entry.getDistance() : null;
+    }
+
+    /**
+     * Clears the "distance to disease extent" cache of all values for a disease (i.e. the extent has changed).
+     * @param diseaseGroupId The id of the disease group.
+     */
+    @Override
+    public void clearDistanceToExtentCacheForDisease(int diseaseGroupId) {
+        distanceToExtentCacheDao.clearCacheForDisease(diseaseGroupId);
+    }
+
+    /**
+     * Add a "distance to disease extent" value to the cache.
+     * @param diseaseGroupId The id of the disease group.
+     * @param locationId The id of the location.
+     * @param distance The distance to cache.
+     */
+    @Override
+    public void saveDistanceToExtentCacheEntry(int diseaseGroupId, int locationId, double distance) {
+        distanceToExtentCacheDao.save(
+                new DistanceToExtentCacheEntry(diseaseGroupId, locationId, distance));
+    }
+
+    @Override
+    public Double getEnvironmentalSuitabilityFromCache(int diseaseGroupId, int locationId) {
+        ValidationParameterCacheEntryId id = new ValidationParameterCacheEntryId(diseaseGroupId, locationId);
+        EnvironmentalSuitabilityCacheEntry entry = environmentalSuitabilityCacheDao.getById(id);
+        return (entry != null) ? entry.getEnvironmentalSuitability() : null;
+    }
+
+    @Override
+    public void clearEnvironmentalSuitabilityCacheForDisease(int diseaseGroupId) {
+        environmentalSuitabilityCacheDao.clearCacheForDisease(diseaseGroupId);
+    }
+
+    @Override
+    public void saveEnvironmentalSuitabilityCacheEntry(int diseaseGroupId, int locationId, double suitability) {
+        environmentalSuitabilityCacheDao.save(
+                new EnvironmentalSuitabilityCacheEntry(diseaseGroupId, locationId, suitability));
+    }
+}

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/DistanceFromDiseaseExtentHelper.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/DistanceFromDiseaseExtentHelper.java
@@ -34,8 +34,23 @@ public class DistanceFromDiseaseExtentHelper {
         DiseaseGroup diseaseGroup = occurrence.getDiseaseGroup();
         Location location = occurrence.getLocation();
 
-        int diseaseGroupId = diseaseGroup.getId();
+        Double distance = locationService.getDistanceToExtentFromCache(diseaseGroup.getId(), location.getId());
+        if (distance != null) {
+            return distance;
+        }
+
+        distance = calculateDistance(diseaseGroup, location);
+
+        if (distance != null) {
+            locationService.saveDistanceToExtentCacheEntry(diseaseGroup.getId(), location.getId(), distance);
+        }
+        return distance;
+    }
+
+    private Double calculateDistance(DiseaseGroup diseaseGroup, Location location) {
         boolean isGlobal = diseaseGroup.isGlobal();
+        int diseaseGroupId = diseaseGroup.getId();
+        int locationId = location.getId();
 
         List<AdminUnitDiseaseExtentClass> diseaseExtentClasses =
                 locationService.getAdminUnitDiseaseExtentClassesForLocation(diseaseGroupId, isGlobal, location);
@@ -51,34 +66,17 @@ public class DistanceFromDiseaseExtentHelper {
         if (insideExtent && outsideExtent) {
             // "Split" country straddling the edge
             return 0.0;
-        } else if (outsideExtent || insideExtent) {
-            return getCachedDistanceOrCalculate(outsideExtent, diseaseGroupId, location.getId(), isGlobal);
+        } else if (outsideExtent) {
+            // We find the distance using a PostGIS query instead of using routines in the GeometryUtils class, because
+            // loading the entire disease extent geometry into memory is likely to be inefficient
+            Double distance = nativeSQL.findDistanceOutsideDiseaseExtent(diseaseGroupId, isGlobal, locationId);
+            return (distance != null) ? (+1.0 * distance) : null;
+        } else if (insideExtent) {
+            Double distance = nativeSQL.findDistanceInsideDiseaseExtent(diseaseGroupId, isGlobal, locationId);
+            return (distance != null) ? (-1.0 * distance) : null;
         } else {
             return null; // No extent defined
         }
-    }
-
-    private Double getCachedDistanceOrCalculate(
-            boolean outsideExtent, int diseaseGroupId, int locationId, boolean isGlobal) {
-        Double distance = locationService.getDistanceToExtentFromCache(diseaseGroupId, locationId);
-        if (distance != null) {
-            return distance;
-        }
-
-        if (outsideExtent) {
-            // We find the distance using a PostGIS query instead of using routines in the GeometryUtils class, because
-            // loading the entire disease extent geometry into memory is likely to be inefficient
-            distance = nativeSQL.findDistanceOutsideDiseaseExtent(diseaseGroupId, isGlobal, locationId);
-            distance = (distance != null) ? (+1.0 * distance) : null;
-        } else {
-            distance = nativeSQL.findDistanceInsideDiseaseExtent(diseaseGroupId, isGlobal, locationId);
-            distance = (distance != null) ? (-1.0 * distance) : null;
-        }
-
-        if (distance != null) {
-            locationService.saveDistanceToExtentCacheEntry(diseaseGroupId, locationId, distance);
-        }
-        return distance;
     }
 
     private boolean containsClass(List<AdminUnitDiseaseExtentClass> diseaseExtentClasses, String extentClass) {

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/DistanceFromDiseaseExtentHelper.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/DistanceFromDiseaseExtentHelper.java
@@ -4,6 +4,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.NativeSQL;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ValidationParameterCacheService;
 
 import java.util.List;
 
@@ -18,10 +19,13 @@ import static org.hamcrest.Matchers.equalTo;
 public class DistanceFromDiseaseExtentHelper {
     private NativeSQL nativeSQL;
     private LocationService locationService;
+    private ValidationParameterCacheService cacheService;
 
-    public DistanceFromDiseaseExtentHelper(NativeSQL nativeSQL, LocationService locationService) {
+    public DistanceFromDiseaseExtentHelper(NativeSQL nativeSQL, LocationService locationService,
+                                           ValidationParameterCacheService cacheService) {
         this.nativeSQL = nativeSQL;
         this.locationService = locationService;
+        this.cacheService = cacheService;
     }
 
     /**
@@ -34,7 +38,7 @@ public class DistanceFromDiseaseExtentHelper {
         DiseaseGroup diseaseGroup = occurrence.getDiseaseGroup();
         Location location = occurrence.getLocation();
 
-        Double distance = locationService.getDistanceToExtentFromCache(diseaseGroup.getId(), location.getId());
+        Double distance = cacheService.getDistanceToExtentFromCache(diseaseGroup.getId(), location.getId());
         if (distance != null) {
             return distance;
         }
@@ -42,7 +46,7 @@ public class DistanceFromDiseaseExtentHelper {
         distance = calculateDistance(diseaseGroup, location);
 
         if (distance != null) {
-            locationService.saveDistanceToExtentCacheEntry(diseaseGroup.getId(), location.getId(), distance);
+            cacheService.saveDistanceToExtentCacheEntry(diseaseGroup.getId(), location.getId(), distance);
         }
         return distance;
     }

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGenerator.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGenerator.java
@@ -5,6 +5,7 @@ import org.joda.time.DateTime;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.DiseaseService;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.GeometryService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationService;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ModelRunService;
 
 import java.util.Collection;
@@ -28,6 +29,7 @@ public class DiseaseExtentGenerator {
     private static final Logger LOGGER = Logger.getLogger(DiseaseExtentGenerator.class);
 
     private ModelRunService modelRunService;
+    private LocationService locationService;
     private DiseaseService diseaseService;
     private DiseaseExtentGenerationInputDataSelector extentDataSelector;
     private DiseaseExtentGeneratorHelperFactory helperFactory;
@@ -37,12 +39,14 @@ public class DiseaseExtentGenerator {
                                   DiseaseExtentGeneratorHelperFactory helperFactory,
                                   GeometryService geometryService,
                                   DiseaseService diseaseService,
-                                  ModelRunService modelRunService) {
+                                  ModelRunService modelRunService,
+                                  LocationService locationService) {
         this.extentDataSelector = extentDataSelector;
         this.helperFactory = helperFactory;
         this.geometryService = geometryService;
         this.diseaseService = diseaseService;
         this.modelRunService = modelRunService;
+        this.locationService = locationService;
     }
 
     /**
@@ -111,6 +115,9 @@ public class DiseaseExtentGenerator {
 
         // Update aggregated extent geometry
         diseaseService.updateAggregatedDiseaseExtent(diseaseGroup);
+
+        // Clear distance cache
+        locationService.clearDistanceToExtentCacheForDisease(diseaseGroup.getId());
 
         // Save input occurrences
         diseaseGroup.getDiseaseExtentParameters()

--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGenerator.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGenerator.java
@@ -3,10 +3,7 @@ package uk.ac.ox.zoo.seeg.abraid.mp.common.service.workflow.support.extent;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.DiseaseService;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.GeometryService;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationService;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ModelRunService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.*;
 
 import java.util.Collection;
 import java.util.Map;
@@ -29,7 +26,7 @@ public class DiseaseExtentGenerator {
     private static final Logger LOGGER = Logger.getLogger(DiseaseExtentGenerator.class);
 
     private ModelRunService modelRunService;
-    private LocationService locationService;
+    private ValidationParameterCacheService cacheService;
     private DiseaseService diseaseService;
     private DiseaseExtentGenerationInputDataSelector extentDataSelector;
     private DiseaseExtentGeneratorHelperFactory helperFactory;
@@ -40,13 +37,13 @@ public class DiseaseExtentGenerator {
                                   GeometryService geometryService,
                                   DiseaseService diseaseService,
                                   ModelRunService modelRunService,
-                                  LocationService locationService) {
+                                  ValidationParameterCacheService cacheService) {
         this.extentDataSelector = extentDataSelector;
         this.helperFactory = helperFactory;
         this.geometryService = geometryService;
         this.diseaseService = diseaseService;
         this.modelRunService = modelRunService;
-        this.locationService = locationService;
+        this.cacheService = cacheService;
     }
 
     /**
@@ -117,7 +114,7 @@ public class DiseaseExtentGenerator {
         diseaseService.updateAggregatedDiseaseExtent(diseaseGroup);
 
         // Clear distance cache
-        locationService.clearDistanceToExtentCacheForDisease(diseaseGroup.getId());
+        cacheService.clearDistanceToExtentCacheForDisease(diseaseGroup.getId());
 
         // Save input occurrences
         diseaseGroup.getDiseaseExtentParameters()

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoTest.java
@@ -8,6 +8,10 @@ import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for DistanceToExtentCacheEntryDao.
+ * Copyright (c) 2015 University of Oxford
+ */
 public class DistanceToExtentCacheEntryDaoTest extends AbstractCommonSpringIntegrationTests {
     @Autowired
     private DistanceToExtentCacheEntryDao distanceToExtentCacheEntryDao;

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.AbstractCommonSpringIntegrationTests;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +27,7 @@ public class DistanceToExtentCacheEntryDaoTest extends AbstractCommonSpringInteg
         // Act
         distanceToExtentCacheEntryDao.save(entry);
         entry = null;
-        entry = distanceToExtentCacheEntryDao.getById(new DistanceToExtentCacheEntryId(87, 6));
+        entry = distanceToExtentCacheEntryDao.getById(new ValidationParameterCacheEntryId(87, 6));
 
         // Assert
         assertThat(entry.getDistance()).isEqualTo(expectedDistance);
@@ -49,7 +49,7 @@ public class DistanceToExtentCacheEntryDaoTest extends AbstractCommonSpringInteg
         distanceToExtentCacheEntryDao.clearCacheForDisease(2);
 
         // Assert
-        assertThat(distanceToExtentCacheEntryDao.getById(new DistanceToExtentCacheEntryId(1, 6))).isNotNull();
-        assertThat(distanceToExtentCacheEntryDao.getById(new DistanceToExtentCacheEntryId(2, 12))).isNotNull();
+        assertThat(distanceToExtentCacheEntryDao.getById(new ValidationParameterCacheEntryId(1, 6))).isNotNull();
+        assertThat(distanceToExtentCacheEntryDao.getById(new ValidationParameterCacheEntryId(2, 12))).isNotNull();
     }
 }

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/dao/DistanceToExtentCacheEntryDaoTest.java
@@ -1,0 +1,51 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.dao;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.AbstractCommonSpringIntegrationTests;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntryId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DistanceToExtentCacheEntryDaoTest extends AbstractCommonSpringIntegrationTests {
+    @Autowired
+    private DistanceToExtentCacheEntryDao distanceToExtentCacheEntryDao;
+
+    @Test
+    public void saveAndReload() {
+        // Arrange
+        int expectedDisease = 87;
+        int expectedLocation = 6;
+        double expectedDistance = -21.24;
+        DistanceToExtentCacheEntry entry = new DistanceToExtentCacheEntry(expectedDisease, expectedLocation, expectedDistance);
+
+        // Act
+        distanceToExtentCacheEntryDao.save(entry);
+        entry = null;
+        entry = distanceToExtentCacheEntryDao.getById(new DistanceToExtentCacheEntryId(87, 6));
+
+        // Assert
+        assertThat(entry.getDistance()).isEqualTo(expectedDistance);
+        assertThat(entry.getId().getDiseaseGroupId()).isEqualTo(expectedDisease);
+        assertThat(entry.getId().getLocationId()).isEqualTo(expectedLocation);
+    }
+
+    @Test
+    public void clearCacheForDisease() {
+        // Arrange
+        distanceToExtentCacheEntryDao.save(new DistanceToExtentCacheEntry(1, 6, 1));
+        distanceToExtentCacheEntryDao.save(new DistanceToExtentCacheEntry(1, 12, 2));
+        distanceToExtentCacheEntryDao.save(new DistanceToExtentCacheEntry(1, 22, 3));
+        distanceToExtentCacheEntryDao.save(new DistanceToExtentCacheEntry(2, 6, 4));
+        distanceToExtentCacheEntryDao.save(new DistanceToExtentCacheEntry(2, 12, 5));
+        distanceToExtentCacheEntryDao.save(new DistanceToExtentCacheEntry(2, 22, 6));
+
+        // Act
+        distanceToExtentCacheEntryDao.clearCacheForDisease(2);
+
+        // Assert
+        assertThat(distanceToExtentCacheEntryDao.getById(new DistanceToExtentCacheEntryId(1, 6))).isNotNull();
+        assertThat(distanceToExtentCacheEntryDao.getById(new DistanceToExtentCacheEntryId(2, 12))).isNotNull();
+    }
+}

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationServiceTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/LocationServiceTest.java
@@ -23,7 +23,6 @@ public class LocationServiceTest {
     private GeoNamesLocationPrecisionDao geoNamesLocationPrecisionDao;
     private GeoNameDao geoNameDao;
     private AdminUnitDiseaseExtentClassDao adminUnitDiseaseExtentClassDao;
-    private DistanceToExtentCacheEntryDao distanceToExtentCacheEntryDao;
 
     @Before
     public void setUp() {
@@ -31,8 +30,7 @@ public class LocationServiceTest {
         geoNamesLocationPrecisionDao = mock(GeoNamesLocationPrecisionDao.class);
         geoNameDao = mock(GeoNameDao.class);
         adminUnitDiseaseExtentClassDao = mock(AdminUnitDiseaseExtentClassDao.class);
-        distanceToExtentCacheEntryDao = mock(DistanceToExtentCacheEntryDao.class);
-        locationService = new LocationServiceImpl(locationDao, geoNamesLocationPrecisionDao, geoNameDao, adminUnitDiseaseExtentClassDao, distanceToExtentCacheEntryDao);
+        locationService = new LocationServiceImpl(locationDao, geoNamesLocationPrecisionDao, geoNameDao, adminUnitDiseaseExtentClassDao);
     }
 
     @Test
@@ -159,49 +157,5 @@ public class LocationServiceTest {
 
         // Assert
         verify(locationDao).save(location);
-    }
-
-    @Test
-    public void getDistanceToExtentFromCacheReturnsCorrectValue() {
-        // Arrange
-        DistanceToExtentCacheEntry mock = mock(DistanceToExtentCacheEntry.class);
-        when(mock.getDistance()).thenReturn(3d);
-        when(distanceToExtentCacheEntryDao.getById(eq(new DistanceToExtentCacheEntryId(1, 2)))).thenReturn(mock);
-
-        // Act
-        Double result = locationService.getDistanceToExtentFromCache(1, 2);
-
-        // Assert
-        assertThat(result).isEqualTo(3d);
-    }
-
-    @Test
-    public void getDistanceToExtentFromCacheReturnsCorrectValueIfNull() {
-        // Arrange
-        when(distanceToExtentCacheEntryDao.getById(eq(new DistanceToExtentCacheEntryId(1, 2)))).thenReturn(null);
-
-        // Act
-        Double result = locationService.getDistanceToExtentFromCache(1, 2);
-
-        // Assert
-        assertThat(result).isNull();
-    }
-
-    @Test
-    public void clearDistanceToExtentCacheForDiseaseCallsDao() {
-        // Act
-        locationService.clearDistanceToExtentCacheForDisease(1);
-
-        // Assert
-        verify(distanceToExtentCacheEntryDao).clearCacheForDisease(1);
-    }
-
-    @Test
-    public void saveDistanceToExtentCacheEntryCallsDao() {
-        // Act
-        locationService.saveDistanceToExtentCacheEntry(1, 2, 3d);
-
-        // Assert
-        verify(distanceToExtentCacheEntryDao).save(eq(new DistanceToExtentCacheEntry(1, 2, 3d)));
     }
 }

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/ValidationParameterCacheServiceTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/core/ValidationParameterCacheServiceTest.java
@@ -1,0 +1,118 @@
+package uk.ac.ox.zoo.seeg.abraid.mp.common.service.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.DistanceToExtentCacheEntryDao;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.EnvironmentalSuitabilityCacheEntryDao;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.DistanceToExtentCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.EnvironmentalSuitabilityCacheEntry;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.ValidationParameterCacheEntryId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for ValidationParameterCacheService.
+ * Copyright (c) 2015 University of Oxford
+ */
+public class ValidationParameterCacheServiceTest {
+    private DistanceToExtentCacheEntryDao distanceToExtentCacheEntryDao;
+    private EnvironmentalSuitabilityCacheEntryDao environmentalSuitabilityCacheEntryDao;
+    private ValidationParameterCacheService validationParameterCacheService;
+
+    @Before
+    public void setUp() {
+        environmentalSuitabilityCacheEntryDao = mock(EnvironmentalSuitabilityCacheEntryDao.class);
+        distanceToExtentCacheEntryDao = mock(DistanceToExtentCacheEntryDao.class);
+        validationParameterCacheService = new ValidationParameterCacheServiceImpl(distanceToExtentCacheEntryDao, environmentalSuitabilityCacheEntryDao);
+    }
+
+    @Test
+    public void getDistanceToExtentFromCacheReturnsCorrectValue() {
+        // Arrange
+        DistanceToExtentCacheEntry mock = mock(DistanceToExtentCacheEntry.class);
+        when(mock.getDistance()).thenReturn(3d);
+        when(distanceToExtentCacheEntryDao.getById(eq(new ValidationParameterCacheEntryId(1, 2)))).thenReturn(mock);
+
+        // Act
+        Double result = validationParameterCacheService.getDistanceToExtentFromCache(1, 2);
+
+        // Assert
+        assertThat(result).isEqualTo(3d);
+    }
+
+    @Test
+    public void getDistanceToExtentFromCacheReturnsCorrectValueIfNull() {
+        // Arrange
+        when(distanceToExtentCacheEntryDao.getById(eq(new ValidationParameterCacheEntryId(1, 2)))).thenReturn(null);
+
+        // Act
+        Double result = validationParameterCacheService.getDistanceToExtentFromCache(1, 2);
+
+        // Assert
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void clearDistanceToExtentCacheForDiseaseCallsDao() {
+        // Act
+        validationParameterCacheService.clearDistanceToExtentCacheForDisease(1);
+
+        // Assert
+        verify(distanceToExtentCacheEntryDao).clearCacheForDisease(1);
+    }
+
+    @Test
+    public void saveDistanceToExtentCacheEntryCallsDao() {
+        // Act
+        validationParameterCacheService.saveDistanceToExtentCacheEntry(1, 2, 3d);
+
+        // Assert
+        verify(distanceToExtentCacheEntryDao).save(eq(new DistanceToExtentCacheEntry(1, 2, 3d)));
+    }
+
+    @Test
+    public void getEnvironmentalSuitabilityFromCacheReturnsCorrectValue() {
+        // Arrange
+        EnvironmentalSuitabilityCacheEntry mock = mock(EnvironmentalSuitabilityCacheEntry.class);
+        when(mock.getEnvironmentalSuitability()).thenReturn(3d);
+        when(environmentalSuitabilityCacheEntryDao.getById(eq(new ValidationParameterCacheEntryId(1, 2)))).thenReturn(mock);
+
+        // Act
+        Double result = validationParameterCacheService.getEnvironmentalSuitabilityFromCache(1, 2);
+
+        // Assert
+        assertThat(result).isEqualTo(3d);
+    }
+
+    @Test
+    public void getEnvironmentalSuitabilityFromCacheReturnsCorrectValueIfNull() {
+        // Arrange
+        when(environmentalSuitabilityCacheEntryDao.getById(eq(new ValidationParameterCacheEntryId(1, 2)))).thenReturn(null);
+
+        // Act
+        Double result = validationParameterCacheService.getEnvironmentalSuitabilityFromCache(1, 2);
+
+        // Assert
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void clearEnvironmentalSuitabilityCacheForDiseaseCallsDao() {
+        // Act
+        validationParameterCacheService.clearEnvironmentalSuitabilityCacheForDisease(1);
+
+        // Assert
+        verify(environmentalSuitabilityCacheEntryDao).clearCacheForDisease(1);
+    }
+
+    @Test
+    public void saveEnvironmentalSuitabilityCacheEntryCallsDao() {
+        // Act
+        validationParameterCacheService.saveEnvironmentalSuitabilityCacheEntry(1, 2, 3d);
+
+        // Assert
+        verify(environmentalSuitabilityCacheEntryDao).save(eq(new EnvironmentalSuitabilityCacheEntry(1, 2, 3d)));
+    }
+}

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/DistanceFromDiseaseExtentHelperTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/DistanceFromDiseaseExtentHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.dao.NativeSQL;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ValidationParameterCacheService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,13 +25,15 @@ public class DistanceFromDiseaseExtentHelperTest {
     private NativeSQL nativeSQL;
     private DistanceFromDiseaseExtentHelper helper;
     private LocationService locationService;
+    private ValidationParameterCacheService cacheService;
 
     @Before
     public void setUp() {
         nativeSQL = mock(NativeSQL.class);
         locationService = mock(LocationService.class);
-        when(locationService.getDistanceToExtentFromCache(anyInt(), anyInt())).thenReturn(null);
-        helper = new DistanceFromDiseaseExtentHelper(nativeSQL, locationService);
+        cacheService = mock(ValidationParameterCacheService.class);
+        when(cacheService.getDistanceToExtentFromCache(anyInt(), anyInt())).thenReturn(null);
+        helper = new DistanceFromDiseaseExtentHelper(nativeSQL, locationService, cacheService);
     }
 
     @Test
@@ -53,7 +56,7 @@ public class DistanceFromDiseaseExtentHelperTest {
 
         // Assert
         assertThat(actualDistance).isEqualTo(expectedDistance);
-        verify(locationService).saveDistanceToExtentCacheEntry(diseaseGroupId, locationId, actualDistance);
+        verify(cacheService).saveDistanceToExtentCacheEntry(diseaseGroupId, locationId, actualDistance);
     }
 
     @Test
@@ -76,7 +79,7 @@ public class DistanceFromDiseaseExtentHelperTest {
 
         // Assert
         assertThat(actualDistance).isEqualTo(-expectedDistance);
-        verify(locationService).saveDistanceToExtentCacheEntry(diseaseGroupId, locationId, actualDistance);
+        verify(cacheService).saveDistanceToExtentCacheEntry(diseaseGroupId, locationId, actualDistance);
     }
 
     @Test
@@ -165,7 +168,7 @@ public class DistanceFromDiseaseExtentHelperTest {
         int locationId = 123;
         double expectedDistance = 25;
         boolean isGlobal = false;
-        when(locationService.getDistanceToExtentFromCache(diseaseGroupId, locationId)).thenReturn(expectedDistance);
+        when(cacheService.getDistanceToExtentFromCache(diseaseGroupId, locationId)).thenReturn(expectedDistance);
         Location location = mock(Location.class);
         when(location.getId()).thenReturn(locationId);
         setupExtentClass(diseaseGroupId, isGlobal, location, DiseaseExtentClass.UNCERTAIN, DiseaseExtentClass.POSSIBLE_ABSENCE, DiseaseExtentClass.ABSENCE);
@@ -185,7 +188,7 @@ public class DistanceFromDiseaseExtentHelperTest {
         int locationId = 123;
         double expectedDistance = -25;
         boolean isGlobal = false;
-        when(locationService.getDistanceToExtentFromCache(diseaseGroupId, locationId)).thenReturn(expectedDistance);
+        when(cacheService.getDistanceToExtentFromCache(diseaseGroupId, locationId)).thenReturn(expectedDistance);
         Location location = mock(Location.class);
         when(location.getId()).thenReturn(locationId);
         setupExtentClass(diseaseGroupId, isGlobal, location, DiseaseExtentClass.POSSIBLE_PRESENCE, DiseaseExtentClass.PRESENCE);

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGeneratorTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGeneratorTest.java
@@ -8,6 +8,7 @@ import org.mockito.stubbing.Answer;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.DiseaseService;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.GeometryService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationService;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ModelRunService;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
     private DiseaseService diseaseService;
     private ModelRunService modelRunService;
     private GeometryService geometryService;
+    private LocationService locationService;
     private DiseaseExtentGenerationInputDataSelector dataSelector;
     private DiseaseExtentGeneratorHelperFactory helperFactory;
 
@@ -41,6 +43,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
         diseaseService = mock(DiseaseService.class);
         modelRunService = mock(ModelRunService.class);
         geometryService = mock(GeometryService.class);
+        locationService = mock(LocationService.class);
         dataSelector = mock(DiseaseExtentGenerationInputDataSelector.class);
         helperFactory = mock(DiseaseExtentGeneratorHelperFactory.class);
         validatorInputData = mock(DiseaseExtentGenerationInputData.class);
@@ -52,7 +55,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
         when(dataSelector.selectForValidatorExtent(eq(diseaseGroup), eq(adminUnits), anyBoolean(), any(DiseaseProcessType.class), any(DateTime.class))).thenReturn(validatorInputData);
         when(dataSelector.selectForModellingExtent(eq(diseaseGroup), eq(validatorInputData))).thenReturn(modellingInputData);
 
-        diseaseExtentGenerator = new DiseaseExtentGenerator(dataSelector, helperFactory, geometryService, diseaseService, modelRunService);
+        diseaseExtentGenerator = new DiseaseExtentGenerator(dataSelector, helperFactory, geometryService, diseaseService, modelRunService, locationService);
         minimumOccurrenceDate = DateTime.now().minusHours(1);
     }
 
@@ -232,6 +235,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
             }
         }
 
+        verify(locationService).clearDistanceToExtentCacheForDisease(diseaseGroup.getId());
         verify(diseaseGroup.getDiseaseExtentParameters()).setLastValidatorExtentUpdateInputOccurrences(occurrencesForLastValidatorExtent);
         verify(diseaseGroup).setLastExtentGenerationDate(eq(DateTime.now()));
         verify(diseaseService).saveDiseaseGroup(diseaseGroup);

--- a/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGeneratorTest.java
+++ b/src/Common/test/uk/ac/ox/zoo/seeg/abraid/mp/common/service/workflow/support/extent/DiseaseExtentGeneratorTest.java
@@ -6,10 +6,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.domain.*;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.DiseaseService;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.GeometryService;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.LocationService;
-import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ModelRunService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +22,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
     private DiseaseService diseaseService;
     private ModelRunService modelRunService;
     private GeometryService geometryService;
-    private LocationService locationService;
+    private ValidationParameterCacheService cacheService;
     private DiseaseExtentGenerationInputDataSelector dataSelector;
     private DiseaseExtentGeneratorHelperFactory helperFactory;
 
@@ -43,7 +40,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
         diseaseService = mock(DiseaseService.class);
         modelRunService = mock(ModelRunService.class);
         geometryService = mock(GeometryService.class);
-        locationService = mock(LocationService.class);
+        cacheService = mock(ValidationParameterCacheService.class);
         dataSelector = mock(DiseaseExtentGenerationInputDataSelector.class);
         helperFactory = mock(DiseaseExtentGeneratorHelperFactory.class);
         validatorInputData = mock(DiseaseExtentGenerationInputData.class);
@@ -55,7 +52,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
         when(dataSelector.selectForValidatorExtent(eq(diseaseGroup), eq(adminUnits), anyBoolean(), any(DiseaseProcessType.class), any(DateTime.class))).thenReturn(validatorInputData);
         when(dataSelector.selectForModellingExtent(eq(diseaseGroup), eq(validatorInputData))).thenReturn(modellingInputData);
 
-        diseaseExtentGenerator = new DiseaseExtentGenerator(dataSelector, helperFactory, geometryService, diseaseService, modelRunService, locationService);
+        diseaseExtentGenerator = new DiseaseExtentGenerator(dataSelector, helperFactory, geometryService, diseaseService, modelRunService, cacheService);
         minimumOccurrenceDate = DateTime.now().minusHours(1);
     }
 
@@ -235,7 +232,7 @@ public class DiseaseExtentGeneratorTest extends BaseDiseaseExtentGenerationTests
             }
         }
 
-        verify(locationService).clearDistanceToExtentCacheForDisease(diseaseGroup.getId());
+        verify(cacheService).clearDistanceToExtentCacheForDisease(diseaseGroup.getId());
         verify(diseaseGroup.getDiseaseExtentParameters()).setLastValidatorExtentUpdateInputOccurrences(occurrencesForLastValidatorExtent);
         verify(diseaseGroup).setLastExtentGenerationDate(eq(DateTime.now()));
         verify(diseaseService).saveDiseaseGroup(diseaseGroup);

--- a/src/ModelOutputHandler/src/uk/ac/ox/zoo/seeg/abraid/mp/modeloutputhandler/web/MainHandler.java
+++ b/src/ModelOutputHandler/src/uk/ac/ox/zoo/seeg/abraid/mp/modeloutputhandler/web/MainHandler.java
@@ -18,6 +18,7 @@ import uk.ac.ox.zoo.seeg.abraid.mp.common.dto.csv.CsvSubmodelStatistic;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.dto.json.JsonModelOutputsMetadata;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.CovariateService;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ModelRunService;
+import uk.ac.ox.zoo.seeg.abraid.mp.common.service.core.ValidationParameterCacheService;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.util.raster.RasterUtils;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.web.JsonParser;
 import uk.ac.ox.zoo.seeg.abraid.mp.common.web.ModelOutputConstants;
@@ -76,17 +77,20 @@ public class MainHandler {
     private final GeoserverRestService geoserver;
     private final RasterFilePathFactory rasterFilePathFactory;
     private final ModelOutputRasterMaskingHelper modelOutputRasterMaskingHelper;
+    private ValidationParameterCacheService cacheService;
 
     public MainHandler(ModelRunService modelRunService,
                        CovariateService covariateService,
                        GeoserverRestService geoserver,
                        RasterFilePathFactory rasterFilePathFactory,
-                       ModelOutputRasterMaskingHelper modelOutputRasterMaskingHelper) {
+                       ModelOutputRasterMaskingHelper modelOutputRasterMaskingHelper,
+                       ValidationParameterCacheService cacheService) {
         this.modelRunService = modelRunService;
         this.covariateService = covariateService;
         this.geoserver = geoserver;
         this.rasterFilePathFactory = rasterFilePathFactory;
         this.modelOutputRasterMaskingHelper = modelOutputRasterMaskingHelper;
+        this.cacheService = cacheService;
     }
 
     /**
@@ -295,6 +299,8 @@ public class MainHandler {
                 if (modelRun.getStatus() == ModelRunStatus.COMPLETED) {
                     geoserver.publishGeoTIFF(maskedFile);
                 }
+
+                cacheService.clearEnvironmentalSuitabilityCacheForDisease(modelRun.getDiseaseGroupId());
             } catch (Exception e) {
                 throw new IOException(String.format(LOG_COULD_NOT_SAVE, PREDICTION_RASTER, modelRun.getName()), e);
             }


### PR DESCRIPTION
Use a database backed cache to store calculated distance to disease extent value to prevent recalculation of the same location for each occurrence (reset cache on extent change).