### PR TITLE
Fix spread table session issue

### DIFF
--- a/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseOccurrence.java
+++ b/src/Common/src/uk/ac/ox/zoo/seeg/abraid/mp/common/domain/DiseaseOccurrence.java
@@ -29,6 +29,7 @@ import javax.persistence.Table;
         @NamedQuery(
                 name = "getDiseaseOccurrencesByDiseaseGroupIdAndStatuses",
                 query = DiseaseOccurrence.DISEASE_OCCURRENCE_BASE_QUERY +
+                        "inner join fetch d.location.country " +
                         "where d.diseaseGroup.id=:diseaseGroupId and d.status in :statuses"
         ),
         @NamedQuery(


### PR DESCRIPTION
Eager load countries in query for disease spread table, to avoid n-country lazy queries, and to avoid lazy query outside of session issue